### PR TITLE
feat(models): add Mistral Medium 3.5-128b and Qwen 3.5 122b-a10b and nvidia/nemotron-3-nano-omni-30b-a3b-reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ That's it — your dashboard auto-refreshes every hour. ✨
 | **MiniMax** | `minimaxai/minimax-m2.7` | Efficient inference model |
 | **MiniMax** | `minimaxai/minimax-m2.5` | Previous generation MiniMax |
 | **NVIDIA** | `nvidia/nemotron-3-super-120b-a12b` | NVIDIA's 120B flagship |
+| **NVIDIA** | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Compact omni reasoning model |
 | **Moonshot** | `moonshotai/kimi-k2.6` | Context-optimized model |
 | **Moonshot** | `moonshotai/kimi-k2-instruct` | Instruction-tuned Kimi |
 | **OpenAI** | `openai/gpt-oss-120b` | Open-source 120B |

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 [![CI](https://github.com/MauroDruwel/NIMStats/actions/workflows/benchmark.yml/badge.svg)](https://github.com/MauroDruwel/NIMStats/actions)
 [![Live Dashboard](https://img.shields.io/badge/🌐%20live-nimstats.maurodruwel.be-76b900?style=flat-square)](https://nimstats.maurodruwel.be/)
-[![Models](https://img.shields.io/badge/models-24-blue?style=flat-square)](https://build.nvidia.com/models)
+[![Models](https://img.shields.io/badge/models-20-blue?style=flat-square)](https://build.nvidia.com/models)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat-square)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](https://github.com/MauroDruwel/NIMStats/pulls)
 [![Stars](https://img.shields.io/github/stars/MauroDruwel/NIMStats?style=flat-square&color=gold)](https://github.com/MauroDruwel/NIMStats/stargazers)
 
 <br/>
 
-> **Community-driven benchmarking of 24 NVIDIA NIM models — fully automated, zero infra cost, self-hostable in minutes.**
+> **Community-driven benchmarking of 20 NVIDIA NIM models — fully automated, zero infra cost, self-hostable in minutes.**
 
 <br/>
 
@@ -23,7 +23,7 @@
 
 ## ✨ What is NIMStats?
 
-NIMStats automatically benchmarks **24 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
+NIMStats automatically benchmarks **20 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
 
 <div align="center">
 
@@ -93,7 +93,7 @@ That's it — your dashboard auto-refreshes every hour. ✨
 ## 🤖 Benchmarked Models
 
 <details>
-<summary><b>24 models across 11 providers — click to expand</b></summary>
+<summary><b>20 models across 11 providers — click to expand</b></summary>
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 [![CI](https://github.com/MauroDruwel/NIMStats/actions/workflows/benchmark.yml/badge.svg)](https://github.com/MauroDruwel/NIMStats/actions)
 [![Live Dashboard](https://img.shields.io/badge/🌐%20live-nimstats.maurodruwel.be-76b900?style=flat-square)](https://nimstats.maurodruwel.be/)
-[![Models](https://img.shields.io/badge/models-23-blue?style=flat-square)](https://build.nvidia.com/models)
+[![Models](https://img.shields.io/badge/models-24-blue?style=flat-square)](https://build.nvidia.com/models)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat-square)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](https://github.com/MauroDruwel/NIMStats/pulls)
 [![Stars](https://img.shields.io/github/stars/MauroDruwel/NIMStats?style=flat-square&color=gold)](https://github.com/MauroDruwel/NIMStats/stargazers)
 
 <br/>
 
-> **Community-driven benchmarking of 23 NVIDIA NIM models — fully automated, zero infra cost, self-hostable in minutes.**
+> **Community-driven benchmarking of 24 NVIDIA NIM models — fully automated, zero infra cost, self-hostable in minutes.**
 
 <br/>
 
@@ -23,7 +23,7 @@
 
 ## ✨ What is NIMStats?
 
-NIMStats automatically benchmarks **23 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
+NIMStats automatically benchmarks **24 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
 
 <div align="center">
 
@@ -93,7 +93,7 @@ That's it — your dashboard auto-refreshes every hour. ✨
 ## 🤖 Benchmarked Models
 
 <details>
-<summary><b>23 models across 11 providers — click to expand</b></summary>
+<summary><b>24 models across 11 providers — click to expand</b></summary>
 
 <br/>
 
@@ -114,6 +114,7 @@ That's it — your dashboard auto-refreshes every hour. ✨
 | **Qwen** | `qwen/qwen3-coder-480b-a35b-instruct` | Specialized coding (480B MoE) |
 | **Qwen** | `qwen/qwen2.5-coder-32b-instruct` | Lightweight Qwen coder |
 | **Qwen** | `qwen/qwen3.5-397b-a17b` | Flagship Qwen (397B) |
+| **Qwen** | `qwen/qwen3.5-122b-a10b` | Mid-range Qwen 3.5 MoE |
 | **Mistral** | `mistralai/devstral-2-123b-instruct-2512` | Developer-focused (123B) |
 | **Mistral** | `mistralai/mistral-large-3-675b-instruct-2512` | Largest Mistral (675B) |
 | **Mistral** | `mistralai/mistral-medium-3.5-128b` | Efficient medium-scale Mistral |

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 [![CI](https://github.com/MauroDruwel/NIMStats/actions/workflows/benchmark.yml/badge.svg)](https://github.com/MauroDruwel/NIMStats/actions)
 [![Live Dashboard](https://img.shields.io/badge/🌐%20live-nimstats.maurodruwel.be-76b900?style=flat-square)](https://nimstats.maurodruwel.be/)
-[![Models](https://img.shields.io/badge/models-22-blue?style=flat-square)](https://build.nvidia.com/models)
+[![Models](https://img.shields.io/badge/models-23-blue?style=flat-square)](https://build.nvidia.com/models)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat-square)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](https://github.com/MauroDruwel/NIMStats/pulls)
 [![Stars](https://img.shields.io/github/stars/MauroDruwel/NIMStats?style=flat-square&color=gold)](https://github.com/MauroDruwel/NIMStats/stargazers)
 
 <br/>
 
-> **Community-driven benchmarking of 22 NVIDIA NIM models — fully automated, zero infra cost, self-hostable in minutes.**
+> **Community-driven benchmarking of 23 NVIDIA NIM models — fully automated, zero infra cost, self-hostable in minutes.**
 
 <br/>
 
@@ -23,7 +23,7 @@
 
 ## ✨ What is NIMStats?
 
-NIMStats automatically benchmarks **22 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
+NIMStats automatically benchmarks **23 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
 
 <div align="center">
 
@@ -93,7 +93,7 @@ That's it — your dashboard auto-refreshes every hour. ✨
 ## 🤖 Benchmarked Models
 
 <details>
-<summary><b>22 models across 11 providers — click to expand</b></summary>
+<summary><b>23 models across 11 providers — click to expand</b></summary>
 
 <br/>
 
@@ -116,6 +116,7 @@ That's it — your dashboard auto-refreshes every hour. ✨
 | **Qwen** | `qwen/qwen3.5-397b-a17b` | Flagship Qwen (397B) |
 | **Mistral** | `mistralai/devstral-2-123b-instruct-2512` | Developer-focused (123B) |
 | **Mistral** | `mistralai/mistral-large-3-675b-instruct-2512` | Largest Mistral (675B) |
+| **Mistral** | `mistralai/mistral-medium-3.5-128b` | Efficient medium-scale Mistral |
 | **Meta** | `meta/llama-3_3-70b-instruct` | Llama 3.3 70B |
 | **Meta** | `meta/llama-4-maverick-17b-128e-instruct` | Llama 4 Maverick (128 experts) |
 | **Meta** | `meta/llama-3.2-90b-vision-instruct` | Multimodal 90B vision model |

--- a/scripts/test_models.py
+++ b/scripts/test_models.py
@@ -28,6 +28,7 @@ ALL_MODELS = [
     "z-ai/glm-5.1",
     "minimaxai/minimax-m2.7",
     "nvidia/nemotron-3-super-120b-a12b",
+    "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
     "moonshotai/kimi-k2.6",
     "openai/gpt-oss-120b",
     "google/gemma-4-31b-it",

--- a/scripts/test_models.py
+++ b/scripts/test_models.py
@@ -35,6 +35,7 @@ ALL_MODELS = [
     "qwen/qwen2.5-coder-32b-instruct",
     "qwen/qwen3.5-397b-a17b",
     "mistralai/mistral-large-3-675b-instruct-2512",
+    "mistralai/mistral-medium-3.5-128b",
     "meta/llama-3_3-70b-instruct",
     "meta/llama-4-maverick-17b-128e-instruct",
     "meta/llama-3.2-90b-vision-instruct",

--- a/scripts/test_models.py
+++ b/scripts/test_models.py
@@ -34,6 +34,7 @@ ALL_MODELS = [
     "qwen/qwen3-coder-480b-a35b-instruct",
     "qwen/qwen2.5-coder-32b-instruct",
     "qwen/qwen3.5-397b-a17b",
+    "qwen/qwen3.5-122b-a10b",
     "mistralai/mistral-large-3-675b-instruct-2512",
     "mistralai/mistral-medium-3.5-128b",
     "meta/llama-3_3-70b-instruct",


### PR DESCRIPTION
Summary:  
  - Add mistralai/mistral-medium-3.5-128b and qwen/qwen3.5-122b-a10b to the benchmark suite
  - Update model count references in README from 17 to 20

Changes:
  - scripts/test_models.py — 2 new model IDs added to ALL_MODELS
  - README.md — badge, tagline, and model count updated to reflect 20 models

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark messaging and counts from 17 to 20 NVIDIA NIM models and expanded the listed models, including added NVIDIA, Qwen, and Mistral entries.

* **Chores**
  * Updated model test configuration to include the new Qwen and Mistral models and adjust the test model ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MauroDruwel/NIMStats/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->