### PR TITLE
fix: normalize DB schema and remove response data

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,11 @@ python3 scripts/test_models.py
 **Schema:**
 
 ```sql
-runs          (id, timestamp, prompt, success_count, total_models, fastest_model, fastest_time)
-model_results (run_id, model, success, error, response_time, tokens_generated, total_tokens, response)
+prompts       (id, text)
+models        (id, name)
+errors        (id, text)
+runs          (id, timestamp, prompt_id, fastest_model_id, fastest_time)
+model_results (run_id, model_id, success, error_id, response_time, tokens_generated, total_tokens)
 ```
 
 **Benchmark parameters:** `temperature: 0.7` · `top_p: 0.9` · `max_tokens: 500` · OpenAI-compatible API

--- a/index.html
+++ b/index.html
@@ -176,8 +176,6 @@ td{padding:10px 16px;color:var(--text);vertical-align:middle}
 .status-badge{display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:4px;font-size:11px;font-weight:600}
 .status-badge.ok{background:var(--success-dim);color:var(--success)}
 .status-badge.fail{background:var(--danger-dim);color:var(--danger)}
-.btn-view{background:var(--bg-card2);border:1px solid var(--border-bright);color:var(--text-dim);font-size:11px;padding:3px 10px;border-radius:4px;cursor:pointer;font-family:'Inter',sans-serif;transition:all 0.2s}
-.btn-view:hover{color:var(--accent);border-color:var(--accent)}
 
 /* Timeline */
 .timeline-controls{display:flex;align-items:center;gap:12px;margin-bottom:20px;flex-wrap:wrap}
@@ -222,22 +220,6 @@ td{padding:10px 16px;color:var(--text);vertical-align:middle}
 .h2h-val-a.winner,.h2h-val-b.winner{color:var(--accent)}
 .h2h-row:hover{background:var(--bg-hover)}
 
-/* Modal */
-#modal{position:fixed;inset:0;z-index:500;display:none;align-items:flex-end;justify-content:center;background:rgba(0,0,0,0.7);backdrop-filter:blur(4px)}
-#modal.open{display:flex;animation:fadeIn 0.2s}
-.modal-box{background:var(--bg-card);border:1px solid var(--border-bright);border-radius:var(--radius) var(--radius) 0 0;width:100%;max-width:900px;max-height:85vh;display:flex;flex-direction:column;animation:slideUp 0.25s ease-out}
-@keyframes slideUp{from{transform:translateY(40px);opacity:0}to{transform:translateY(0);opacity:1}}
-@keyframes fadeIn{from{opacity:0}to{opacity:1}}
-.modal-header{display:flex;align-items:center;gap:12px;padding:18px 24px;border-bottom:1px solid var(--border);flex-shrink:0}
-.modal-title{font-size:14px;font-weight:600;color:var(--text);font-family:'JetBrains Mono',monospace;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.modal-close{background:none;border:none;color:var(--text-dim);font-size:20px;cursor:pointer;line-height:1;padding:4px 8px;border-radius:4px;transition:color 0.2s}
-.modal-close:hover{color:var(--text)}
-.modal-copy{background:var(--bg-card2);border:1px solid var(--border-bright);color:var(--text-dim);font-size:12px;padding:5px 12px;border-radius:var(--radius-sm);cursor:pointer;font-family:'Inter',sans-serif;transition:all 0.2s}
-.modal-copy:hover{color:var(--accent);border-color:var(--accent)}
-.modal-body{flex:1;overflow-y:auto;padding:20px 24px}
-.modal-body pre{background:var(--bg-card2);border:1px solid var(--border);border-radius:var(--radius-sm);padding:16px;overflow-x:auto;font-family:'JetBrains Mono',monospace;font-size:12px;line-height:1.6;color:var(--accent);margin:12px 0}
-.modal-body p{margin-bottom:10px;color:var(--text);font-size:14px;line-height:1.7}
-.modal-body code{font-family:'JetBrains Mono',monospace;font-size:12px;background:var(--bg-card2);padding:1px 5px;border-radius:3px;color:var(--blue)}
 
 /* Section headers */
 .section-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:20px}
@@ -396,7 +378,7 @@ td{padding:10px 16px;color:var(--text);vertical-align:middle}
           <div class="card-title"><span class="dot"></span>Run History (last 20)</div>
           <div class="run-table-wrap">
             <table class="run-table">
-              <thead><tr><th>Timestamp</th><th>Status</th><th>Response Time</th><th>Tok/s</th><th>Action</th></tr></thead>
+              <thead><tr><th>Timestamp</th><th>Status</th><th>Response Time</th><th>Tok/s</th></tr></thead>
               <tbody id="explorer-run-table"></tbody>
             </table>
           </div>
@@ -455,18 +437,6 @@ td{padding:10px 16px;color:var(--text);vertical-align:middle}
   </main>
 </div>
 
-<!-- Response Modal -->
-<div id="modal">
-  <div class="modal-box" id="modal-box">
-    <div class="modal-header">
-      <span class="provider-chip" id="modal-provider-chip"></span>
-      <div class="modal-title" id="modal-title"></div>
-      <button class="modal-copy" id="modal-copy">Copy</button>
-      <button class="modal-close" id="modal-close">✕</button>
-    </div>
-    <div class="modal-body" id="modal-body"></div>
-  </div>
-</div>
 
 <script>
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -518,8 +488,7 @@ const state = {
   explorerModel: 'qwen/qwen3-coder-480b-a35b-instruct',
   lbSort: { col: 'score', dir: 'desc' },
   lbFilter: '',
-  timelineFilter: 'all',
-  modalResponse: ''
+  timelineFilter: 'all'
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -629,30 +598,6 @@ function sparklineSVG(values, width = 80, height = 24, color = '#76b900') {
   return `<svg width="${width}" height="${height}" style="overflow:visible"><path d="${d}" stroke="${color}" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/><circle cx="${lastX.toFixed(1)}" cy="${lastY.toFixed(1)}" r="2.5" fill="${color}"/></svg>`;
 }
 
-function renderMarkdown(text) {
-  if (!text) return '';
-  // Code blocks
-  text = text.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) => {
-    return `<pre><code class="lang-${lang}">${escHtml(code.trimEnd())}</code></pre>`;
-  });
-  // Inline code
-  text = text.replace(/`([^`]+)`/g, (_, c) => `<code>${escHtml(c)}</code>`);
-  // Bold
-  text = text.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
-  // Paragraphs
-  const lines = text.split('\n');
-  const out = [];
-  let inPre = false;
-  for (const line of lines) {
-    if (line.startsWith('<pre>')) inPre = true;
-    if (line.endsWith('</pre>')) { inPre = false; out.push(line); continue; }
-    if (inPre) { out.push(line); continue; }
-    if (line.trim() === '') { out.push(''); continue; }
-    out.push(`<p>${line}</p>`);
-  }
-  return out.join('\n');
-}
-
 function escHtml(s) {
   return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 }
@@ -660,22 +605,30 @@ function escHtml(s) {
 // ─── SQLite Data Loader ───────────────────────────────────────────────────────
 function loadFromDb(db) {
   const runsQ = db.exec(
-    'SELECT id, timestamp, prompt, success_count, total_models, fastest_model, fastest_time FROM runs ORDER BY timestamp DESC'
+    `SELECT r.id, r.timestamp, p.text, m.name, r.fastest_time
+     FROM runs r
+     JOIN prompts p ON r.prompt_id = p.id
+     LEFT JOIN models m ON r.fastest_model_id = m.id
+     ORDER BY r.timestamp DESC`
   );
   if (!runsQ.length || !runsQ[0].values.length) return { runs: [] };
 
-  const runs = runsQ[0].values.map(([id, timestamp, prompt, sc, tm, fm, ft]) => ({
+  const runs = runsQ[0].values.map(([id, timestamp, prompt, fm, ft]) => ({
     _dbId: id,
     timestamp,
     prompt,
     models: [],
-    summary: { successCount: sc, totalModels: tm, fastestModel: fm, fastestTime: ft }
+    summary: { fastestModel: fm || 'N/A', fastestTime: ft || 0 }
   }));
 
   const runById = new Map(runs.map((r, i) => [r._dbId, i]));
 
   const resQ = db.exec(
-    'SELECT run_id, model, success, error, response_time, tokens_generated, total_tokens FROM model_results ORDER BY run_id ASC'
+    `SELECT mr.run_id, m.name, mr.success, e.text, mr.response_time, mr.tokens_generated, mr.total_tokens
+     FROM model_results mr
+     JOIN models m ON mr.model_id = m.id
+     LEFT JOIN errors e ON mr.error_id = e.id
+     ORDER BY mr.run_id ASC`
   );
   if (resQ.length && resQ[0].values.length) {
     for (const [run_id, model, success, error, rt, tg, tt] of resQ[0].values) {
@@ -688,11 +641,17 @@ function loadFromDb(db) {
           responseTime: rt,
           tokensGenerated: tg,
           totalTokens: tt,
-          response: null  // lazy-loaded on demand
         });
       }
     }
   }
+
+  // Derive success count and total models per run
+  for (const run of runs) {
+    run.summary.successCount = run.models.filter(m => m.success).length;
+    run.summary.totalModels = run.models.length;
+  }
+
   return { runs };
 }
 
@@ -1177,32 +1136,15 @@ function renderExplorer() {
   const tbody = document.getElementById('explorer-run-table');
   const last20 = s.results.map((r, i) => ({ r, i })).slice(-20).reverse();
   tbody.innerHTML = last20.map(({ r, i }) => {
-    if (!r) return `<tr><td class="mono text-dim">${fmtTimestamp(state.runs[i]?.timestamp||'')}</td><td>—</td><td>—</td><td>—</td><td>—</td></tr>`;
+    if (!r) return `<tr><td class="mono text-dim">${fmtTimestamp(state.runs[i]?.timestamp||'')}</td><td>—</td><td>—</td><td>—</td></tr>`;
     const tps = (r.success && r.responseTime > 0) ? (r.tokensGenerated / (r.responseTime / 1000)).toFixed(1) : null;
-    const actionBtn = r.success
-      ? `<button class="btn-view" data-run="${i}">View</button>` : '—';
     return `<tr>
       <td class="mono" style="font-size:11px">${fmtTimestamp(state.runs[i]?.timestamp||'')}</td>
       <td><span class="status-badge ${r.success?'ok':'fail'}">${r.success?'✓ OK':'✗ Fail'}</span></td>
       <td class="mono">${r.success ? (r.responseTime/1000).toFixed(2)+'s' : '—'}</td>
       <td class="mono">${tps ? tps+' t/s' : '—'}</td>
-      <td>${actionBtn}</td>
     </tr>`;
   }).join('');
-
-  tbody.querySelectorAll('.btn-view[data-run]').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const idx = parseInt(btn.dataset.run);
-      const run = state.runs[idx];
-      if (!run) return;
-      const q = state.db.exec(
-        'SELECT response FROM model_results WHERE run_id = ? AND model = ?',
-        [run._dbId, model]
-      );
-      const response = q[0]?.values[0]?.[0] || '';
-      openModal(model, response);
-    });
-  });
 }
 
 // ─── Timeline Tab ─────────────────────────────────────────────────────────────
@@ -1439,21 +1381,6 @@ function renderCompare() {
   });
 }
 
-// ─── Modal ────────────────────────────────────────────────────────────────────
-function openModal(model, response) {
-  state.modalResponse = response || '';
-  const pm = providerMeta(model);
-  document.getElementById('modal-provider-chip').textContent = pm.name;
-  document.getElementById('modal-provider-chip').style.cssText = `background:${pm.color}22;color:${pm.color};border:1px solid ${pm.color}44`;
-  document.getElementById('modal-title').textContent = model;
-  document.getElementById('modal-body').innerHTML = renderMarkdown(response || '');
-  document.getElementById('modal').classList.add('open');
-}
-
-function closeModal() {
-  document.getElementById('modal').classList.remove('open');
-}
-
 // ─── Tab Navigation ───────────────────────────────────────────────────────────
 function switchTab(tabName) {
   state.currentTab = tabName;
@@ -1512,17 +1439,6 @@ async function init() {
     // Nav tabs
     document.querySelectorAll('.nav-tab[data-goto]').forEach(btn => {
       btn.addEventListener('click', () => switchTab(btn.dataset.goto));
-    });
-
-    // Modal controls
-    document.getElementById('modal-close').addEventListener('click', closeModal);
-    document.getElementById('modal').addEventListener('click', e => { if (e.target === e.currentTarget) closeModal(); });
-    document.getElementById('modal-copy').addEventListener('click', () => {
-      navigator.clipboard?.writeText(state.modalResponse).then(() => {
-        const btn = document.getElementById('modal-copy');
-        btn.textContent = 'Copied!';
-        setTimeout(() => btn.textContent = 'Copy', 1500);
-      });
     });
 
     // Initial render

--- a/scripts/db_utils.py
+++ b/scripts/db_utils.py
@@ -10,32 +10,51 @@ MAX_RUNS = 720
 
 
 def init_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA journal_mode = WAL")
     conn.executescript("""
-        PRAGMA journal_mode=WAL;
+        CREATE TABLE IF NOT EXISTS prompts (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            text TEXT NOT NULL UNIQUE
+        );
+        CREATE TABLE IF NOT EXISTS models (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE
+        );
+        CREATE TABLE IF NOT EXISTS errors (
+            id   INTEGER PRIMARY KEY AUTOINCREMENT,
+            text TEXT UNIQUE
+        );
         CREATE TABLE IF NOT EXISTS runs (
-            id            INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp     TEXT    NOT NULL,
-            prompt        TEXT,
-            success_count INTEGER,
-            total_models  INTEGER,
-            fastest_model TEXT,
-            fastest_time  INTEGER
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp        TEXT    NOT NULL,
+            prompt_id        INTEGER NOT NULL REFERENCES prompts(id),
+            fastest_model_id INTEGER          REFERENCES models(id),
+            fastest_time     INTEGER
         );
         CREATE TABLE IF NOT EXISTS model_results (
-            id               INTEGER PRIMARY KEY AUTOINCREMENT,
             run_id           INTEGER NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
-            model            TEXT    NOT NULL,
+            model_id         INTEGER NOT NULL REFERENCES models(id),
             success          INTEGER NOT NULL DEFAULT 0,
-            error            TEXT,
+            error_id         INTEGER          REFERENCES errors(id),
             response_time    INTEGER,
             tokens_generated INTEGER,
             total_tokens     INTEGER,
-            response         TEXT
+            PRIMARY KEY (run_id, model_id)
         );
-        CREATE INDEX IF NOT EXISTS idx_mr_run   ON model_results(run_id);
-        CREATE INDEX IF NOT EXISTS idx_mr_model ON model_results(model);
         CREATE INDEX IF NOT EXISTS idx_runs_ts  ON runs(timestamp);
+        CREATE INDEX IF NOT EXISTS idx_mr_model ON model_results(model_id);
     """)
+
+
+def _get_or_create(conn: sqlite3.Connection, table: str, col: str, value: Any) -> int | None:
+    if not value:
+        return None
+    row = conn.execute(f"SELECT id FROM {table} WHERE {col} = ?", (value,)).fetchone()
+    if row:
+        return row[0]
+    cur = conn.execute(f"INSERT INTO {table} ({col}) VALUES (?)", (value,))
+    return cur.lastrowid
 
 
 def write_run(run: dict[str, Any], db_path: Path = HISTORY_DB) -> None:
@@ -44,37 +63,34 @@ def write_run(run: dict[str, Any], db_path: Path = HISTORY_DB) -> None:
     conn = sqlite3.connect(str(db_path))
     try:
         init_schema(conn)
+        prompt_id = _get_or_create(conn, "prompts", "text", run.get("prompt"))
+        fastest_model_id = _get_or_create(conn, "models", "name", summary.get("fastestModel"))
+
         cur = conn.execute(
-            """INSERT INTO runs (timestamp, prompt, success_count, total_models, fastest_model, fastest_time)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (
-                run.get("timestamp"),
-                run.get("prompt"),
-                summary.get("successCount"),
-                summary.get("totalModels"),
-                summary.get("fastestModel"),
-                summary.get("fastestTime"),
-            ),
+            """INSERT INTO runs (timestamp, prompt_id, fastest_model_id, fastest_time)
+               VALUES (?, ?, ?, ?)""",
+            (run.get("timestamp"), prompt_id, fastest_model_id, summary.get("fastestTime")),
         )
         run_id = cur.lastrowid
-        conn.executemany(
-            """INSERT INTO model_results
-               (run_id, model, success, error, response_time, tokens_generated, total_tokens, response)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            [
+
+        for m in run.get("models", []):
+            model_id = _get_or_create(conn, "models", "name", m.get("model"))
+            error_id = _get_or_create(conn, "errors", "text", m.get("error"))
+            conn.execute(
+                """INSERT INTO model_results
+                   (run_id, model_id, success, error_id, response_time, tokens_generated, total_tokens)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
                 (
                     run_id,
-                    m.get("model"),
+                    model_id,
                     1 if m.get("success") else 0,
-                    m.get("error"),
+                    error_id,
                     m.get("responseTime"),
                     m.get("tokensGenerated"),
                     m.get("totalTokens"),
-                    m.get("response"),
-                )
-                for m in run.get("models", [])
-            ],
-        )
+                ),
+            )
+
         conn.execute(
             f"DELETE FROM runs WHERE id NOT IN "
             f"(SELECT id FROM runs ORDER BY timestamp DESC LIMIT {MAX_RUNS})"

--- a/scripts/migrate_normalized.py
+++ b/scripts/migrate_normalized.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Migration: rebuild history.db with the normalized schema.
+
+Drops the response column, deduplicates model/error/prompt text into lookup
+tables, removes orphaned model_results, and VACUUMs the file.
+Run from the repo root: python3 scripts/migrate_normalized.py
+"""
+
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from db_utils import HISTORY_DB, init_schema  # noqa: E402
+
+
+def migrate(db_path: Path = HISTORY_DB) -> int:
+    if not db_path.exists():
+        print(f"Error: {db_path} not found", file=sys.stderr)
+        return 1
+
+    old_size = db_path.stat().st_size
+    print(f"Migrating {db_path} ({old_size // 1024} KB) …")
+
+    tmp_path = db_path.with_suffix(".db.tmp")
+    if tmp_path.exists():
+        tmp_path.unlink()
+
+    src = sqlite3.connect(str(db_path))
+    src.execute("PRAGMA foreign_keys = OFF")
+    dst = sqlite3.connect(str(tmp_path))
+    init_schema(dst)
+
+    # Populate lookup tables
+    for (text,) in src.execute("SELECT DISTINCT prompt FROM runs WHERE prompt IS NOT NULL"):
+        dst.execute("INSERT INTO prompts (text) VALUES (?)", (text,))
+
+    for (name,) in src.execute("SELECT DISTINCT model FROM model_results WHERE model IS NOT NULL"):
+        dst.execute("INSERT OR IGNORE INTO models (name) VALUES (?)", (name,))
+    for (name,) in src.execute(
+        "SELECT DISTINCT fastest_model FROM runs WHERE fastest_model IS NOT NULL AND fastest_model != ''"
+    ):
+        dst.execute("INSERT OR IGNORE INTO models (name) VALUES (?)", (name,))
+
+    for (text,) in src.execute("SELECT DISTINCT error FROM model_results WHERE error IS NOT NULL"):
+        dst.execute("INSERT INTO errors (text) VALUES (?)", (text,))
+
+    # Copy runs (only those that still exist — pruned run IDs are skipped)
+    for r_id, ts, prompt, fm, ft in src.execute(
+        "SELECT id, timestamp, prompt, fastest_model, fastest_time FROM runs ORDER BY id"
+    ):
+        p_id = dst.execute("SELECT id FROM prompts WHERE text=?", (prompt,)).fetchone()
+        p_id = p_id[0] if p_id else None
+        fm_id = None
+        if fm:
+            row = dst.execute("SELECT id FROM models WHERE name=?", (fm,)).fetchone()
+            fm_id = row[0] if row else None
+        dst.execute(
+            "INSERT INTO runs (id, timestamp, prompt_id, fastest_model_id, fastest_time) VALUES (?,?,?,?,?)",
+            (r_id, ts, p_id, fm_id, ft),
+        )
+
+    # Copy model_results (only for runs that exist — orphans are dropped)
+    for run_id, model, success, error, rt, tg, tt in src.execute(
+        "SELECT run_id, model, success, error, response_time, tokens_generated, total_tokens "
+        "FROM model_results WHERE run_id IN (SELECT id FROM runs)"
+    ):
+        m_id = dst.execute("SELECT id FROM models WHERE name=?", (model,)).fetchone()[0]
+        e_id = None
+        if error:
+            row = dst.execute("SELECT id FROM errors WHERE text=?", (error,)).fetchone()
+            e_id = row[0] if row else None
+        dst.execute(
+            "INSERT INTO model_results "
+            "(run_id, model_id, success, error_id, response_time, tokens_generated, total_tokens) "
+            "VALUES (?,?,?,?,?,?,?)",
+            (run_id, m_id, success, e_id, rt, tg, tt),
+        )
+
+    dst.commit()
+    dst.execute("VACUUM")
+    run_count = dst.execute("SELECT COUNT(*) FROM runs").fetchone()[0]
+    result_count = dst.execute("SELECT COUNT(*) FROM model_results").fetchone()[0]
+    dst.close()
+    src.close()
+
+    # Replace old DB
+    db_path.unlink()
+    tmp_path.rename(db_path)
+
+    new_size = db_path.stat().st_size
+    print("Done: Migration complete")
+    print(f"  {run_count} runs · {result_count} model results")
+    print(f"  Size: {old_size // 1024} KB -> {new_size // 1024} KB ({(1 - new_size / old_size) * 100:.0f}% smaller)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(migrate())

--- a/scripts/migrate_to_sqlite.py
+++ b/scripts/migrate_to_sqlite.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from db_utils import HISTORY_DB, init_schema  # noqa: E402
+from db_utils import HISTORY_DB, init_schema, _get_or_create  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HISTORY_JSON = REPO_ROOT / "history.json"
@@ -44,9 +44,6 @@ def main() -> int:
         removed_entries += len(run.get("models", [])) - len(models)
 
         summary = run.get("summary", {})
-        success_count = sum(1 for m in models if m.get("success"))
-        total_count = len(models)
-
         fastest_model = summary.get("fastestModel")
         fastest_time = summary.get("fastestTime", 0) or 0
         if fastest_model in REMOVED_MODELS:
@@ -59,31 +56,35 @@ def main() -> int:
                 fastest_model = "N/A"
                 fastest_time = 0
 
+        prompt_id = _get_or_create(conn, "prompts", "text", run.get("prompt"))
+        fastest_model_id = _get_or_create(conn, "models", "name", fastest_model) if fastest_model and fastest_model != "N/A" else None
+
         cur = conn.execute(
-            """INSERT INTO runs (timestamp, prompt, success_count, total_models, fastest_model, fastest_time)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (run.get("timestamp"), run.get("prompt"), success_count, total_count, fastest_model, fastest_time),
+            """INSERT INTO runs (timestamp, prompt_id, fastest_model_id, fastest_time)
+               VALUES (?, ?, ?, ?)""",
+            (run.get("timestamp"), prompt_id, fastest_model_id, fastest_time),
         )
         run_id = cur.lastrowid
-        conn.executemany(
-            """INSERT INTO model_results
-               (run_id, model, success, error, response_time, tokens_generated, total_tokens, response)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            [
+
+        for m in models:
+            model_id = _get_or_create(conn, "models", "name", m.get("model"))
+            error_id = _get_or_create(conn, "errors", "text", m.get("error"))
+            conn.execute(
+                """INSERT INTO model_results
+                   (run_id, model_id, success, error_id, response_time, tokens_generated, total_tokens)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
                 (
                     run_id,
-                    m.get("model"),
+                    model_id,
                     1 if m.get("success") else 0,
-                    m.get("error"),
+                    error_id,
                     m.get("responseTime"),
                     m.get("tokensGenerated"),
                     m.get("totalTokens"),
-                    m.get("response"),
-                )
-                for m in models
-            ],
-        )
+                ),
+            )
 
+    conn.execute("VACUUM")
     conn.commit()
 
     run_count = conn.execute("SELECT COUNT(*) FROM runs").fetchone()[0]


### PR DESCRIPTION
## Summary

Fixes #12 — \history.db\ was 34 MB, causing Cloudflare to refuse serving the page.

**Reduced from 34 MB to 684 KB (98% smaller).**

### Root causes & fixes

| Problem | Size impact | Fix |
|---|---|---|
| \esponse\ column stored raw LLM output (same prompt every time, not useful to users) | 23 MB | Removed column entirely |
| 10,484 orphaned \model_results\ rows — \PRAGMA foreign_keys\ was OFF so \ON DELETE CASCADE\ never fired when pruning old runs | ~5 MB | Enabled \oreign_keys=ON\ |
| Duplicate text: 20 model names × 24K rows, 30 errors × 7K rows, 1 prompt × 720 rows | ~1 MB | Normalized into lookup tables (\prompts\, \models\, \rrors\) |
| Unnecessary autoincrement \id\ PK on \model_results\ | overhead | Composite PK \(run_id, model_id)\ |
| Redundant \success_count\/\	otal_models\ columns on \uns\ | overhead | Derived in JS from \model_results\ |

### Schema (after)

\\\
prompts       (id, text)
models        (id, name)
errors        (id, text)
runs          (id, timestamp, prompt_id, fastest_model_id, fastest_time)
model_results (run_id, model_id, success, error_id, response_time, tokens_generated, total_tokens)
\\\

### Frontend changes
- Updated \loadFromDb\ queries with JOINs through lookup tables
- Removed response viewer modal (HTML, CSS, JS, View button, \enderMarkdown\)

### New files
- \scripts/migrate_normalized.py\ — one-time migration script for existing DBs

Closes #12