### PR TITLE
chore: update model list to match available API models

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@
 
 ## ✨ What is NIMStats?
 
-NIMStats benchmarks **22 NVIDIA NIM models** using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
+NIMStats automatically benchmarks **22 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
 
 <div align="center">
 
-| 🏎️ On-Demand Benchmarks | 📊 Interactive Charts | 🔁 Zero Infrastructure | 🌍 Fully Open-Source |
+| 🏎️ Hourly Benchmarks | 📊 Interactive Charts | 🔁 Zero Infrastructure | 🌍 Fully Open-Source |
 |:---:|:---:|:---:|:---:|
-| Run via GitHub Actions | Response time, throughput & trends | Static site + free CI/CD | Fork and self-host in minutes |
+| Automatic via GitHub Actions | Response time, throughput & trends | Static site + free CI/CD | Fork and self-host in minutes |
 
 </div>
 
@@ -70,7 +70,7 @@ In your forked repo: **Settings → Secrets and variables → Actions → New re
 
 **Actions → Benchmark NVIDIA NIM Models → Run workflow**
 
-That's it — your dashboard is live! Run benchmarks on-demand from the Actions tab. ✨
+That's it — your dashboard auto-refreshes every hour. ✨
 
 ---
 
@@ -129,17 +129,17 @@ That's it — your dashboard is live! Run benchmarks on-demand from the Actions 
 ## 🏗️ How It Works
 
 ````
-┌──────────────────── GitHub Actions (manual trigger) ───────────────────┐
-│                                                                        │
-│   ┌─────────────────────┐        ┌─────────────────────┐                │
-│   │  Job 1 — Group A    │        │  Job 2 — Group B    │ (parallel)    │
-│   │  11 NIM models      │        │  11 NIM models      │                │
-│   └──────────┬──────────┘        └──────────┬──────────┘                │
-│              └──────────────┬───────────────┘                           │
+┌──────────────────── GitHub Actions (every hour) ────────────────────┐
+│                                                                       │
+│   ┌─────────────────────┐        ┌─────────────────────┐              │
+│   │  Job 1 — Group A    │        │  Job 2 — Group B    │ (parallel)  │
+│   │  11 NIM models      │        │  11 NIM models      │              │
+│   └──────────┬──────────┘        └──────────┬──────────┘              │
+│              └──────────────┬───────────────┘                         │
 │                    ┌────────▼────────┐                                 │
-│                    │  Merge + commit │ → history.db committed to repo  │
+│                    │  Merge + commit │ → history.db committed to repo │
 │                    └─────────────────┘                                 │
-└────────────────────────────────────────────────────────────────────────┘
+└───────────────────────────────────────────────────────────────────────┘
                               │
                    ┌──────────▼──────────┐
                    │  Cloudflare Pages     │ → auto-deploys on push
@@ -148,8 +148,6 @@ That's it — your dashboard is live! Run benchmarks on-demand from the Actions 
 ````
 
 **Parallel jobs = ~50% faster benchmarks** ⚡
-
-> **Note:** The benchmark runs on manual trigger (`workflow_dispatch`). Set up a [scheduled trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) if you want hourly runs. Cloudflare Pages automatically deploys the dashboard whenever `main` is updated.
 
 ---
 
@@ -177,14 +175,11 @@ ALL_MODELS = [
 </details>
 
 <details>
-<summary><b>Add a schedule (optional)</b></summary>
+<summary><b>Change the schedule</b></summary>
 
-The benchmark runs on manual trigger by default. To run automatically, add a `schedule` trigger to `.github/workflows/benchmark.yml`:
+Edit `.github/workflows/benchmark.yml`:
 ```yaml
-on:
-  schedule:
-    - cron: '0 */6 * * *'  # Every 6 hours
-  workflow_dispatch:
+- cron: '0 */6 * * *'  # Every 6 hours instead of every hour
 ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 [![CI](https://github.com/MauroDruwel/NIMStats/actions/workflows/benchmark.yml/badge.svg)](https://github.com/MauroDruwel/NIMStats/actions)
 [![Live Dashboard](https://img.shields.io/badge/🌐%20live-nimstats.maurodruwel.be-76b900?style=flat-square)](https://nimstats.maurodruwel.be/)
-[![Models](https://img.shields.io/badge/models-20-blue?style=flat-square)](https://build.nvidia.com/models)
+[![Models](https://img.shields.io/badge/models-22-blue?style=flat-square)](https://build.nvidia.com/models)
 [![License: MIT](https://img.shields.io/badge/license-MIT-yellow?style=flat-square)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](https://github.com/MauroDruwel/NIMStats/pulls)
 [![Stars](https://img.shields.io/github/stars/MauroDruwel/NIMStats?style=flat-square&color=gold)](https://github.com/MauroDruwel/NIMStats/stargazers)
 
 <br/>
 
-> **Community-driven benchmarking of 20 NVIDIA NIM models — fully automated, zero infra cost, self-hostable in minutes.**
+> **Community-driven benchmarking of 22 NVIDIA NIM models — fully automated, zero infra cost, self-hostable in minutes.**
 
 <br/>
 
@@ -23,7 +23,7 @@
 
 ## ✨ What is NIMStats?
 
-NIMStats automatically benchmarks **20 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
+NIMStats automatically benchmarks **22 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
 
 <div align="center">
 
@@ -93,7 +93,7 @@ That's it — your dashboard auto-refreshes every hour. ✨
 ## 🤖 Benchmarked Models
 
 <details>
-<summary><b>20 models across 11 providers — click to expand</b></summary>
+<summary><b>22 models across 11 providers — click to expand</b></summary>
 
 <br/>
 
@@ -101,25 +101,22 @@ That's it — your dashboard auto-refreshes every hour. ✨
 |----------|-------|-----------|
 | **DeepSeek** | `deepseek-ai/deepseek-v4-flash` | Fast MoE, optimized for speed |
 | **DeepSeek** | `deepseek-ai/deepseek-v4-pro` | Professional-grade reasoning |
-| **DeepSeek** | `deepseek-ai/deepseek-v3.2` | Latest with improved reasoning |
-| **Z-AI** | `z-ai/glm-5.1` | Superior code understanding |
-| **Z-AI** | `z-ai/glm-4.7` | Strong mathematical capabilities |
+| **Z-AI** | `z-ai/glm-5.2` | Superior code understanding |
 | **MiniMax** | `minimaxai/minimax-m2.7` | Efficient inference model |
-| **MiniMax** | `minimaxai/minimax-m2.5` | Previous generation MiniMax |
+| **MiniMax** | `minimaxai/minimax-m3` | Latest MiniMax generation |
 | **NVIDIA** | `nvidia/nemotron-3-super-120b-a12b` | NVIDIA's 120B flagship |
 | **NVIDIA** | `nvidia/nemotron-3-nano-omni-30b-a3b-reasoning` | Compact omni reasoning model |
+| **NVIDIA** | `nvidia/llama-3.3-nemotron-super-49b-v1.5` | Nemotron Super 49B v1.5 |
 | **Moonshot** | `moonshotai/kimi-k2.6` | Context-optimized model |
-| **Moonshot** | `moonshotai/kimi-k2-instruct` | Instruction-tuned Kimi |
 | **OpenAI** | `openai/gpt-oss-120b` | Open-source 120B |
 | **Google** | `google/gemma-4-31b-it` | Lightweight edge inference |
-| **Qwen** | `qwen/qwen3-coder-480b-a35b-instruct` | Specialized coding (480B MoE) |
-| **Qwen** | `qwen/qwen2.5-coder-32b-instruct` | Lightweight Qwen coder |
 | **Qwen** | `qwen/qwen3.5-397b-a17b` | Flagship Qwen (397B) |
 | **Qwen** | `qwen/qwen3.5-122b-a10b` | Mid-range Qwen 3.5 MoE |
-| **Mistral** | `mistralai/devstral-2-123b-instruct-2512` | Developer-focused (123B) |
+| **Qwen** | `qwen/qwen3-next-80b-a3b-instruct` | Next-gen Qwen (80B MoE) |
 | **Mistral** | `mistralai/mistral-large-3-675b-instruct-2512` | Largest Mistral (675B) |
 | **Mistral** | `mistralai/mistral-medium-3.5-128b` | Efficient medium-scale Mistral |
-| **Meta** | `meta/llama-3_3-70b-instruct` | Llama 3.3 70B |
+| **Mistral** | `mistralai/mistral-small-4-119b-2603` | Mistral Small 4 (119B) |
+| **Meta** | `meta/llama-3.3-70b-instruct` | Llama 3.3 70B |
 | **Meta** | `meta/llama-4-maverick-17b-128e-instruct` | Llama 4 Maverick (128 experts) |
 | **Meta** | `meta/llama-3.2-90b-vision-instruct` | Multimodal 90B vision model |
 | **StepFun** | `stepfun-ai/step-3.5-flash` | Ultra-fast flash model |
@@ -136,7 +133,7 @@ That's it — your dashboard auto-refreshes every hour. ✨
 │                                                                               │
 │   ┌─────────────────────┐        ┌─────────────────────┐                    │
 │   │  Job 1 — Group A    │        │  Job 2 — Group B    │  (run in parallel) │
-│   │  10 NIM models      │        │  10 NIM models      │                    │
+│   │  11 NIM models      │        │  11 NIM models      │                    │
 │   └──────────┬──────────┘        └──────────┬──────────┘                    │
 │              └──────────────┬───────────────┘                               │
 │                    ┌────────▼────────┐                                       │

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@
 
 ## ✨ What is NIMStats?
 
-NIMStats automatically benchmarks **22 NVIDIA NIM models** every hour using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
+NIMStats benchmarks **22 NVIDIA NIM models** using GitHub Actions and publishes the results to a beautiful, interactive dashboard. No servers, no subscriptions — just fork, add your API key, and go.
 
 <div align="center">
 
-| 🏎️ Hourly Benchmarks | 📊 Interactive Charts | 🔁 Zero Infrastructure | 🌍 Fully Open-Source |
+| 🏎️ On-Demand Benchmarks | 📊 Interactive Charts | 🔁 Zero Infrastructure | 🌍 Fully Open-Source |
 |:---:|:---:|:---:|:---:|
-| Automatic via GitHub Actions | Response time, throughput & trends | Static site + free CI/CD | Fork and self-host in minutes |
+| Run via GitHub Actions | Response time, throughput & trends | Static site + free CI/CD | Fork and self-host in minutes |
 
 </div>
 
@@ -62,7 +62,7 @@ In your forked repo: **Settings → Secrets and variables → Actions → New re
 
 | Platform | Steps |
 |----------|-------|
-| **Cloudflare Pages** | Connect repo in [Cloudflare Pages](https://pages.cloudflare.com/) |
+| **Cloudflare Pages** | Connect repo → auto-deploys on every push to `main` |
 | **GitHub Pages** | Settings → Pages → Deploy from `main` |
 | **Netlify / Vercel** | Connect repo for instant auto-deploy |
 
@@ -70,7 +70,7 @@ In your forked repo: **Settings → Secrets and variables → Actions → New re
 
 **Actions → Benchmark NVIDIA NIM Models → Run workflow**
 
-That's it — your dashboard auto-refreshes every hour. ✨
+That's it — your dashboard is live! Run benchmarks on-demand from the Actions tab. ✨
 
 ---
 
@@ -128,26 +128,28 @@ That's it — your dashboard auto-refreshes every hour. ✨
 
 ## 🏗️ How It Works
 
-```
-┌──────────────────── GitHub Actions (every hour) ──────────────────────┐
-│                                                                               │
-│   ┌─────────────────────┐        ┌─────────────────────┐                    │
-│   │  Job 1 — Group A    │        │  Job 2 — Group B    │  (run in parallel) │
-│   │  11 NIM models      │        │  11 NIM models      │                    │
-│   └──────────┬──────────┘        └──────────┬──────────┘                    │
-│              └──────────────┬───────────────┘                               │
-│                    ┌────────▼────────┐                                       │
-│                    │  Merge + commit │  → history.db updated in repo         │
-│                    └─────────────────┘                                       │
-└───────────────────────────────────────────────────────────────────────────── ┘
-                                     │
-                          ┌──────────▼──────────┐
-                          │  Static Dashboard   │  rebuilds on each push
-                          │  (Pages / Netlify)  │
-                          └─────────────────────┘
-```
+````
+┌──────────────────── GitHub Actions (manual trigger) ───────────────────┐
+│                                                                        │
+│   ┌─────────────────────┐        ┌─────────────────────┐                │
+│   │  Job 1 — Group A    │        │  Job 2 — Group B    │ (parallel)    │
+│   │  11 NIM models      │        │  11 NIM models      │                │
+│   └──────────┬──────────┘        └──────────┬──────────┘                │
+│              └──────────────┬───────────────┘                           │
+│                    ┌────────▼────────┐                                 │
+│                    │  Merge + commit │ → history.db committed to repo  │
+│                    └─────────────────┘                                 │
+└────────────────────────────────────────────────────────────────────────┘
+                              │
+                   ┌──────────▼──────────┐
+                   │  Cloudflare Pages     │ → auto-deploys on push
+                   │  (static dashboard)  │   index.html + history.db
+                   └──────────────────────┘
+````
 
 **Parallel jobs = ~50% faster benchmarks** ⚡
+
+> **Note:** The benchmark runs on manual trigger (`workflow_dispatch`). Set up a [scheduled trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) if you want hourly runs. Cloudflare Pages automatically deploys the dashboard whenever `main` is updated.
 
 ---
 
@@ -175,11 +177,14 @@ ALL_MODELS = [
 </details>
 
 <details>
-<summary><b>Change the schedule</b></summary>
+<summary><b>Add a schedule (optional)</b></summary>
 
-Edit `.github/workflows/benchmark.yml`:
+The benchmark runs on manual trigger by default. To run automatically, add a `schedule` trigger to `.github/workflows/benchmark.yml`:
 ```yaml
-- cron: '0 */6 * * *'  # Every 6 hours instead of every hour
+on:
+  schedule:
+    - cron: '0 */6 * * *'  # Every 6 hours
+  workflow_dispatch:
 ```
 </details>
 

--- a/scripts/test_models.py
+++ b/scripts/test_models.py
@@ -25,29 +25,31 @@ OUTPUT_FILE = SCRIPT_DIR / "results.json"
 ALL_MODELS = [
     "deepseek-ai/deepseek-v4-flash",
     "deepseek-ai/deepseek-v4-pro",
-    "z-ai/glm-5.1",
+    "z-ai/glm-5.2",
     "minimaxai/minimax-m2.7",
+    "minimaxai/minimax-m3",
     "nvidia/nemotron-3-super-120b-a12b",
     "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+    "nvidia/llama-3.3-nemotron-super-49b-v1.5",
     "moonshotai/kimi-k2.6",
     "openai/gpt-oss-120b",
     "google/gemma-4-31b-it",
-    "qwen/qwen3-coder-480b-a35b-instruct",
-    "qwen/qwen2.5-coder-32b-instruct",
     "qwen/qwen3.5-397b-a17b",
     "qwen/qwen3.5-122b-a10b",
+    "qwen/qwen3-next-80b-a3b-instruct",
     "mistralai/mistral-large-3-675b-instruct-2512",
     "mistralai/mistral-medium-3.5-128b",
-    "meta/llama-3_3-70b-instruct",
+    "mistralai/mistral-small-4-119b-2603",
+    "meta/llama-3.3-70b-instruct",
     "meta/llama-4-maverick-17b-128e-instruct",
     "meta/llama-3.2-90b-vision-instruct",
     "stepfun-ai/step-3.5-flash",
     "stepfun-ai/step-3.7-flash"
 ]
 
-GROUP1_MODELS = ALL_MODELS[:10]
+GROUP1_MODELS = ALL_MODELS[:11]
 
-GROUP2_MODELS = ALL_MODELS[10:]
+GROUP2_MODELS = ALL_MODELS[11:]
 
 
 def selected_models() -> list[str]:


### PR DESCRIPTION
## Summary

Cross-referenced the 20 tested models against the [NVIDIA NIM API](https://integrate.api.nvidia.com/v1/models). Found 4 that are no longer available and 6 interesting new ones to add.

### Removed (4 — no longer on the API)
| Model | Reason |
|---|---|
| \z-ai/glm-5.1\ | Replaced by \z-ai/glm-5.2\ |
| \qwen/qwen3-coder-480b-a35b-instruct\ | Delisted |
| \qwen/qwen2.5-coder-32b-instruct\ | Delisted |
| \meta/llama-3_3-70b-instruct\ | Renamed to \meta/llama-3.3-70b-instruct\ (dots not underscores) |

### Added (6)
| Model | Why |
|---|---|
| \z-ai/glm-5.2\ | Direct upgrade from glm-5.1 |
| \minimaxai/minimax-m3\ | Newer than m2.7 |
| \
vidia/llama-3.3-nemotron-super-49b-v1.5\ | Latest Nemotron Super |
| \qwen/qwen3-next-80b-a3b-instruct\ | New Qwen model |
| \mistralai/mistral-small-4-119b-2603\ | New Mistral Small |
| \meta/llama-3.3-70b-instruct\ | Correct name for the old \llama-3_3-70b-instruct\ |

**Total: 20 → 22 models**, rebalanced to 11 + 11 per group.

### Files changed
- \scripts/test_models.py\ — updated \ALL_MODELS\ list
- \README.md\ — badge (22), model table, workflow diagram (11+11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded benchmark coverage from 20 to 22 models.
  * Updated the benchmark lineup with newer model entries and revised provider/model groupings.

* **Documentation**
  * Refreshed the README to reflect the larger model set, updated benchmark counts, and revised diagrams/table entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->