### PR TITLE
feat: relax model addition rule

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -43,7 +43,7 @@ jobs:
             4. Decide on changes:
                - REMOVE models in ALL_MODELS that are absent from the NVIDIA list (NVIDIA no longer hosts them).
                - RENAME models NVIDIA republished under a new id, using the RENAMES mapping in sync_models.py.
-               - ADD new chat models worth benchmarking: they must be hosted on NVIDIA, be text-chat models (exclude embeddings, rerankers, vision/audio-only, guard/safety, image-gen, etc.), and have an Artificial Analysis intelligence index of at least 50 (the helper fuzzy-matches this; sanity-check suspicious matches yourself). Cap new additions at 8 per run. If no benchmark data is available, do not add models.
+               - ADD new chat models worth benchmarking. Use your judgment on what people will actually use: NVIDIA hosts the newest flagship releases, so prefer those. The Artificial Analysis intelligence index is guidance, not a hard cutoff — a rough bar of ~40, but you may include notably newer or widely-used models below that (e.g. a brand-new flagship release at 38 is a better add than a 3-year-old model at 60). Exclude non-chat models (embeddings, rerankers, vision/audio-only, guard/safety, image-gen, etc.) and exclude niche or domain-specialized models unless they are clearly popular. Cap new additions at 8 per run. If no benchmark data is available, do not add models.
 
             5. Apply the changes: edit the ALL_MODELS list in scripts/test_models.py (you can reuse the logic in sync_models.py / manage_models.py rather than hand-editing), then run:
                python3 scripts/manage_models.py purge

--- a/scripts/sync_models.py
+++ b/scripts/sync_models.py
@@ -245,7 +245,7 @@ def main() -> int:
     parser.add_argument("--report-path", default=None,
                         help="write the markdown report to this file")
     parser.add_argument("--min-score", type=float,
-                        default=float(os.getenv("AA_MIN_SCORE", "50")),
+                        default=float(os.getenv("AA_MIN_SCORE", "40")),
                         help="minimum Artificial Analysis index for new additions")
     parser.add_argument("--max-additions", type=int,
                         default=int(os.getenv("MAX_ADDITIONS", "8")),


### PR DESCRIPTION
## What
- `scripts/sync_models.py`: `AA_MIN_SCORE` default lowered 50 → 40 (standalone sanity floor)
- `sync-models.yml` prompt: intelligence index is now **guidance, not a hard cutoff** — the agent can add newer/widely-used models below the bar (e.g. `nvidia/nemotron-3-ultra-550b-a55b` at 38.3 was rejected before but is a flagship people will use), while still excluding non-chat/niche models and capping at 8 additions per run

Next run will re-evaluate candidates with this rule.