### PR TITLE
feat: add sitemap.xml, robots.txt and 404.html for search engines

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>404 - NIMStats</title>
+<meta name="robots" content="noindex">
+<style>
+  body{font-family:'Outfit',system-ui,sans-serif;background:#17181c;color:#e8eaed;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:100vh;margin:0;gap:8px}
+  h1{font-size:64px;margin:0;color:#76b900}
+  p{color:#9aa0a6}
+  a{color:#76b900}
+</style>
+</head>
+<body>
+<h1>404</h1>
+<p>This page does not exist.</p>
+<p><a href="/">← Back to NIMStats</a></p>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://nimstats.maurodruwel.be/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://nimstats.maurodruwel.be/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://nimstats.maurodruwel.be/?tab=explorer</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Why
The sitemap validation in Google Search Console has been stuck in "Started" since 7 July. Cloudflare Pages serves `index.html` (HTTP 200, `text/html`) for **every unknown path** — including `/sitemap.xml` — so Google received the dashboard HTML where it expected XML and the validation can never succeed.

## What
- **`sitemap.xml`** — single-page site, so just the homepage + `?tab=explorer`
- **`robots.txt`** — points crawlers at the sitemap
- **`404.html`** — unknown paths now return a real 404 instead of the dashboard HTML, so crawlers stop treating fallback HTML as pages

## After merging
1. In Search Console: re-submit `https://nimstats.maurodruwel.be/sitemap.xml`
2. URL Inspection → `https://nimstats.maurodruwel.be/` → "Request indexing"

Note: the dashboard is a client-side JS app, so expect modest indexing value — but the sitemap will finally validate.