### PR TITLE
feat: bilingual EN/zh i18n toggle (English default)

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,47 +32,48 @@
 
 <div id="loading">
   <div class="spinner"></div>
-  <p>Loading benchmark data…</p>
+  <p data-i18n="loading.text">正在加载基准测试数据…</p>
 </div>
 
 <div id="app">
   <nav>
     <div class="nav-brand">NIM<span>Stats</span></div>
     <div class="nav-tabs">
-      <button class="nav-tab active" data-goto="overview">📊 Overview</button>
-      <button class="nav-tab" data-goto="leaderboard">🏆 Leaderboard</button>
-      <button class="nav-tab" data-goto="explorer">🔬 Explorer</button>
-      <button class="nav-tab" data-goto="timeline">⏱ Timeline</button>
-      <button class="nav-tab" data-goto="compare">⚔️ Compare</button>
+      <button class="nav-tab active" data-goto="overview">📊 <span data-i18n="nav.overview">概览</span></button>
+      <button class="nav-tab" data-goto="leaderboard">🏆 <span data-i18n="nav.leaderboard">排行榜</span></button>
+      <button class="nav-tab" data-goto="explorer">🔬 <span data-i18n="nav.explorer">模型详情</span></button>
+      <button class="nav-tab" data-goto="timeline">⏱ <span data-i18n="nav.timeline">时间线</span></button>
+      <button class="nav-tab" data-goto="compare">⚔️ <span data-i18n="nav.compare">对比</span></button>
     </div>
-    <button class="theme-toggle" id="theme-toggle" title="Toggle Theme" aria-label="Toggle theme">
+    <button class="theme-toggle" id="theme-toggle" title="切换主题" data-i18n-title="theme.toggle" aria-label="切换主题">
       <span class="theme-icon-light">☀️</span>
       <span class="theme-icon-dark">🌙</span>
     </button>
+    <select class="lang-toggle" id="lang-select" onchange="setLang(this.value)" title="切换语言 / Switch language" style="height:32px;padding:0 8px;margin-left:8px;border-radius:8px;border:1px solid var(--border);background:var(--bg-card2);color:var(--text);font-family:'Outfit',sans-serif;font-weight:600;font-size:13px;cursor:pointer"></select>
     <div class="nav-status" id="nav-status"></div>
   </nav>
 
   <main>
     <div id="error-state">
       <div class="err-icon">⚠️</div>
-      <h2>Failed to load benchmark data</h2>
-      <p id="error-msg">Could not fetch history.db. Make sure the file exists and you're serving this page via HTTP.</p>
+      <h2 data-i18n="error.title">加载基准测试数据失败</h2>
+      <p id="error-msg">无法获取 history.db。请确保该文件存在，且通过 HTTP 方式访问本页面。</p>
     </div>
 
     <!-- OVERVIEW -->
     <section data-tab="overview" class="active">
       <div class="section-header mb-4">
         <div>
-          <div class="section-title">Dashboard Overview</div>
+          <div class="section-title" data-i18n="ov.title">仪表盘概览</div>
           <div class="section-sub" id="overview-sub"></div>
         </div>
         <div class="filter-controls">
-          <span class="filter-label">Runs limit:</span>
+          <span class="filter-label" data-i18n="ov.runs_limit">运行次数：</span>
           <div class="filter-btns">
-            <button class="filter-btn" data-limit="30">30 runs</button>
-            <button class="filter-btn" data-limit="50">50 runs</button>
-            <button class="filter-btn" data-limit="100">100 runs</button>
-            <button class="filter-btn" data-limit="all">All</button>
+            <button class="filter-btn" data-limit="30" data-i18n="ov.limit.30">30 次</button>
+            <button class="filter-btn" data-limit="50" data-i18n="ov.limit.50">50 次</button>
+            <button class="filter-btn" data-limit="100" data-i18n="ov.limit.100">100 次</button>
+            <button class="filter-btn" data-limit="all" data-i18n="ov.limit.all">全部</button>
           </div>
         </div>
       </div>
@@ -81,36 +82,36 @@
       <!-- Intelligence & Capability Analysis -->
       <div class="chart-row chart-row-2" style="margin-bottom:20px">
         <div class="card">
-          <div class="card-title"><span class="dot" style="background:var(--purple)"></span>Model Intelligence Index</div>
-          <div class="chart-wrap" style="position:relative"><canvas id="chart-intelligence-bar"></canvas><div id="overview-no-intel" class="no-data" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:12px;color:var(--text-dim)">⚠️ Supply ARTIFICIAL_ANALYSIS_API_KEY to load benchmark scores</div></div>
+          <div class="card-title"><span class="dot" style="background:var(--purple)"></span><span data-i18n="card.model_intel">模型智能指数</span></div>
+          <div class="chart-wrap" style="position:relative"><canvas id="chart-intelligence-bar"></canvas><div id="overview-no-intel" class="no-data" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:12px;color:var(--text-dim)" data-i18n="no_intel">⚠️ 请提供 ARTIFICIAL_ANALYSIS_API_KEY 以加载基准分数</div></div>
         </div>
         <div class="card">
-          <div class="card-title"><span class="dot" style="background:var(--blue)"></span>Intelligence vs. Throughput (Value Frontier)</div>
-          <div class="chart-wrap" style="position:relative"><canvas id="chart-intelligence-scatter"></canvas><div id="overview-no-scatter" class="no-data" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:12px;color:var(--text-dim)">⚠️ Supply ARTIFICIAL_ANALYSIS_API_KEY to load value frontier</div></div>
+          <div class="card-title"><span class="dot" style="background:var(--blue)"></span><span data-i18n="card.value_frontier">智能 vs. 吞吐（价值前沿）</span></div>
+          <div class="chart-wrap" style="position:relative"><canvas id="chart-intelligence-scatter"></canvas><div id="overview-no-scatter" class="no-data" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:12px;color:var(--text-dim)" data-i18n="no_scatter">⚠️ 请提供 ARTIFICIAL_ANALYSIS_API_KEY 以加载价值前沿</div></div>
         </div>
       </div>
 
       <div class="chart-row chart-row-2" style="margin-bottom:20px">
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Success Count per Run</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.success_count">每次运行成功数</span></div>
           <div class="chart-wrap"><canvas id="chart-success-count"></canvas></div>
         </div>
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Success Rate Over Time</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.success_rate">成功率趋势</span></div>
           <div class="chart-wrap"><canvas id="chart-success-rate"></canvas></div>
         </div>
       </div>
       <div class="chart-row chart-row-3">
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Top 10 Fastest Models (Avg)</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.fastest">最快模型 Top 10（平均）</span></div>
           <div class="chart-wrap-lg"><canvas id="chart-fastest"></canvas></div>
         </div>
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Top 10 Throughput (tok/s)</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.throughput">最高吞吐 Top 10（tok/s）</span></div>
           <div class="chart-wrap-lg"><canvas id="chart-throughput"></canvas></div>
         </div>
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Model Reliability</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.reliability">模型可靠性</span></div>
           <div class="reliability-grid" id="reliability-grid" style="height:260px;overflow-y:auto"></div>
         </div>
       </div>
@@ -120,37 +121,37 @@
     <section data-tab="leaderboard">
       <div class="section-header mb-4">
         <div>
-          <div class="section-title">Model Leaderboard</div>
-          <div class="section-sub">Ranked by composite score - click a row to explore that model</div>
+          <div class="section-title" data-i18n="lb.title">模型排行榜</div>
+          <div class="section-sub" data-i18n="lb.sub">按综合评分排名 - 点击某行查看该模型详情</div>
         </div>
         <div class="filter-controls">
-          <span class="filter-label">Runs limit:</span>
+          <span class="filter-label" data-i18n="ov.runs_limit">运行次数：</span>
           <div class="filter-btns">
-            <button class="filter-btn" data-limit="30">30 runs</button>
-            <button class="filter-btn" data-limit="50">50 runs</button>
-            <button class="filter-btn" data-limit="100">100 runs</button>
-            <button class="filter-btn" data-limit="all">All</button>
+            <button class="filter-btn" data-limit="30" data-i18n="ov.limit.30">30 次</button>
+            <button class="filter-btn" data-limit="50" data-i18n="ov.limit.50">50 次</button>
+            <button class="filter-btn" data-limit="100" data-i18n="ov.limit.100">100 次</button>
+            <button class="filter-btn" data-limit="all" data-i18n="ov.limit.all">全部</button>
           </div>
         </div>
       </div>
       <div class="table-controls">
-        <input class="search-input" id="lb-search" type="text" placeholder="🔍 Filter by model name…">
+        <input class="search-input" id="lb-search" type="text" data-i18n-ph="lb.search_ph" placeholder="🔍 按模型名称筛选…">
       </div>
       <div class="table-wrap">
         <table id="lb-table">
           <thead>
             <tr>
-              <th data-col="rank" class="sorted"># <span class="sort-arrow">↓</span></th>
-              <th data-col="model">Model</th>
-              <th data-col="score">Score <span class="sort-arrow">↓</span></th>
-              <th data-col="uptime">Uptime <span class="sort-arrow"></span></th>
-              <th data-col="intelligence">Intel <span class="sort-arrow"></span></th>
-              <th data-col="avgTime">Avg Time <span class="sort-arrow"></span></th>
-              <th data-col="avgTtft">TTFT <span class="sort-arrow"></span></th>
-              <th data-col="bestTime">Best Time <span class="sort-arrow"></span></th>
-              <th data-col="avgTps">Throughput <span class="sort-arrow"></span></th>
-              <th data-col="wins">Wins <span class="sort-arrow"></span></th>
-              <th data-col="trend">Trend</th>
+              <th data-col="rank" class="sorted"><span data-i18n="th.rank">#</span> <span class="sort-arrow">↓</span></th>
+              <th data-col="model"><span data-i18n="th.model">模型</span></th>
+              <th data-col="score"><span data-i18n="th.score">评分</span> <span class="sort-arrow">↓</span></th>
+              <th data-col="uptime"><span data-i18n="th.uptime">在线率</span> <span class="sort-arrow"></span></th>
+              <th data-col="intelligence"><span data-i18n="th.intelligence">智能</span> <span class="sort-arrow"></span></th>
+              <th data-col="avgTime"><span data-i18n="th.avgTime">平均耗时</span> <span class="sort-arrow"></span></th>
+              <th data-col="avgTtft"><span data-i18n="th.avgTtft">首字延迟</span> <span class="sort-arrow"></span></th>
+              <th data-col="bestTime"><span data-i18n="th.bestTime">最佳耗时</span> <span class="sort-arrow"></span></th>
+              <th data-col="avgTps"><span data-i18n="th.avgTps">吞吐</span> <span class="sort-arrow"></span></th>
+              <th data-col="wins"><span data-i18n="th.wins">胜场</span> <span class="sort-arrow"></span></th>
+              <th data-col="trend"><span data-i18n="th.trend">趋势</span></th>
             </tr>
           </thead>
           <tbody id="lb-body"></tbody>
@@ -162,27 +163,27 @@
     <section data-tab="explorer">
       <div class="explorer-selectors mb-4">
         <div class="model-selector-wrap">
-          <div class="model-selector-label">Select Model</div>
+          <div class="model-selector-label" data-i18n="ex.select_model">选择模型</div>
           <div class="custom-select-container" id="explorer-custom-select">
             <button class="custom-select-trigger" aria-haspopup="listbox" aria-expanded="false">
-              <span class="trigger-content">Select a model...</span>
+              <span class="trigger-content">请选择模型…</span>
               <span class="trigger-arrow">▼</span>
             </button>
             <div class="custom-select-dropdown">
               <div class="dropdown-search-wrap">
-                <input type="text" class="dropdown-search-input" placeholder="🔍 Search models...">
+                <input type="text" class="dropdown-search-input" data-i18n-ph="ex.search_ph" placeholder="🔍 搜索模型…">
               </div>
               <ul class="dropdown-list" role="listbox"></ul>
             </div>
           </div>
         </div>
         <div class="filter-controls">
-          <span class="filter-label">Runs limit:</span>
+          <span class="filter-label" data-i18n="ov.runs_limit">运行次数：</span>
           <div class="filter-btns">
-            <button class="filter-btn" data-limit="30">30 runs</button>
-            <button class="filter-btn" data-limit="50">50 runs</button>
-            <button class="filter-btn" data-limit="100">100 runs</button>
-            <button class="filter-btn" data-limit="all">All</button>
+            <button class="filter-btn" data-limit="30" data-i18n="ov.limit.30">30 次</button>
+            <button class="filter-btn" data-limit="50" data-i18n="ov.limit.50">50 次</button>
+            <button class="filter-btn" data-limit="100" data-i18n="ov.limit.100">100 次</button>
+            <button class="filter-btn" data-limit="all" data-i18n="ov.limit.all">全部</button>
           </div>
         </div>
       </div>
@@ -192,41 +193,41 @@
       <!-- Model Capability & Benchmark Profile -->
       <div class="chart-row chart-row-2" style="margin-bottom:20px">
         <div class="card">
-          <div class="card-title"><span class="dot" style="background:var(--success)"></span>Model Capability Breakdown (Radar)</div>
+          <div class="card-title"><span class="dot" style="background:var(--success)"></span><span data-i18n="card.radar">模型能力拆解（雷达图）</span></div>
           <div style="position:relative;height:280px;display:flex;align-items:center;justify-content:center">
             <canvas id="chart-explorer-radar"></canvas>
-            <div id="explorer-no-radar" class="no-data" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:12px;color:var(--text-dim)">⚠️ Supply ARTIFICIAL_ANALYSIS_API_KEY to view radar capabilities</div>
+            <div id="explorer-no-radar" class="no-data" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:12px;color:var(--text-dim)" data-i18n="no_radar">⚠️ 请提供 ARTIFICIAL_ANALYSIS_API_KEY 以查看能力雷达图</div>
           </div>
         </div>
         <div class="card">
-          <div class="card-title"><span class="dot" style="background:var(--warning)"></span>Model Performance vs. Global Average</div>
-          <div class="chart-wrap" style="position:relative"><canvas id="chart-explorer-comparison"></canvas><div id="explorer-no-comparison" class="no-data" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:12px;color:var(--text-dim)">⚠️ Supply ARTIFICIAL_ANALYSIS_API_KEY to view comparison stats</div></div>
+          <div class="card-title"><span class="dot" style="background:var(--warning)"></span><span data-i18n="card.compare_profile">模型表现 vs. 全局平均</span></div>
+          <div class="chart-wrap" style="position:relative"><canvas id="chart-explorer-comparison"></canvas><div id="explorer-no-comparison" class="no-data" style="display:none;position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:12px;color:var(--text-dim)" data-i18n="no_comparison">⚠️ 请提供 ARTIFICIAL_ANALYSIS_API_KEY 以查看对比数据</div></div>
         </div>
       </div>
 
       <div class="chart-row chart-row-2" style="margin-bottom:20px">
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Response Time History</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.resp_history">响应时间历史</span></div>
           <div class="chart-wrap-lg"><canvas id="chart-explorer-time"></canvas></div>
         </div>
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Error Breakdown</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.error_breakdown">错误分布</span></div>
           <div style="position:relative;height:260px;display:flex;align-items:center;justify-content:center">
             <canvas id="chart-explorer-errors"></canvas>
-            <div id="explorer-no-errors" class="no-data" style="display:none">🎉 100% Success Rate - No Errors!</div>
+            <div id="explorer-no-errors" class="no-data" style="display:none" data-i18n="no_errors">🎉 100% 成功率 - 无错误！</div>
           </div>
         </div>
       </div>
       <div class="chart-row chart-row-2">
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Availability Heatmap</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.heatmap">可用性热力图</span></div>
           <div class="heatmap" id="explorer-heatmap"></div>
         </div>
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Run History (last 20)</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.run_history">运行历史（最近 20 次）</span></div>
           <div class="run-table-wrap">
             <table class="run-table">
-              <thead><tr><th>Timestamp</th><th>Status</th><th>Response Time</th><th>Tok/s</th></tr></thead>
+              <thead><tr><th data-i18n="th.timestamp">时间</th><th data-i18n="th.status">状态</th><th data-i18n="th.response_time">响应时间</th><th data-i18n="th.tok_s">Tok/s</th></tr></thead>
               <tbody id="explorer-run-table"></tbody>
             </table>
           </div>
@@ -237,15 +238,15 @@
     <!-- TIMELINE -->
     <section data-tab="timeline">
       <div class="section-header mb-4">
-        <div><div class="section-title">Run Timeline</div></div>
+        <div><div class="section-title" data-i18n="tl.title">运行时间线</div></div>
       </div>
       <div class="timeline-controls">
         <div class="run-badge" id="timeline-badge"></div>
         <div class="filter-btns">
-          <button class="filter-btn active" data-filter="all">All</button>
-          <button class="filter-btn" data-filter="24h">Last 24h</button>
-          <button class="filter-btn" data-filter="48h">Last 48h</button>
-          <button class="filter-btn" data-filter="7d">Last 7d</button>
+          <button class="filter-btn active" data-filter="all" data-i18n="tl.filter.all">全部</button>
+          <button class="filter-btn" data-filter="24h" data-i18n="tl.filter.24h">最近 24 小时</button>
+          <button class="filter-btn" data-filter="48h" data-i18n="tl.filter.48h">最近 48 小时</button>
+          <button class="filter-btn" data-filter="7d" data-i18n="tl.filter.7d">最近 7 天</button>
         </div>
       </div>
       <div class="run-cards" id="run-cards"></div>
@@ -255,46 +256,46 @@
     <section data-tab="compare">
       <div class="section-header mb-4">
         <div>
-          <div class="section-title">Model Comparison</div>
-          <div class="section-sub">Head-to-head analysis</div>
+          <div class="section-title" data-i18n="cmp.title">模型对比</div>
+          <div class="section-sub" data-i18n="cmp.sub">一对一对比分析</div>
         </div>
         <div class="filter-controls">
-          <span class="filter-label">Runs limit:</span>
+          <span class="filter-label" data-i18n="ov.runs_limit">运行次数：</span>
           <div class="filter-btns">
-            <button class="filter-btn" data-limit="30">30 runs</button>
-            <button class="filter-btn" data-limit="50">50 runs</button>
-            <button class="filter-btn" data-limit="100">100 runs</button>
-            <button class="filter-btn" data-limit="all">All</button>
+            <button class="filter-btn" data-limit="30" data-i18n="ov.limit.30">30 次</button>
+            <button class="filter-btn" data-limit="50" data-i18n="ov.limit.50">50 次</button>
+            <button class="filter-btn" data-limit="100" data-i18n="ov.limit.100">100 次</button>
+            <button class="filter-btn" data-limit="all" data-i18n="ov.limit.all">全部</button>
           </div>
         </div>
       </div>
       <div class="compare-selectors">
         <div class="selector-group">
-          <label>Model A</label>
+          <label data-i18n="cmp.model_a">模型 A</label>
           <div class="custom-select-container" id="compare-a-custom-select">
             <button class="custom-select-trigger" aria-haspopup="listbox" aria-expanded="false">
-              <span class="trigger-content">Select model...</span>
+              <span class="trigger-content">请选择模型…</span>
               <span class="trigger-arrow">▼</span>
             </button>
             <div class="custom-select-dropdown">
               <div class="dropdown-search-wrap">
-                <input type="text" class="dropdown-search-input" placeholder="🔍 Search models...">
+                <input type="text" class="dropdown-search-input" data-i18n-ph="ex.search_ph" placeholder="🔍 搜索模型…">
               </div>
               <ul class="dropdown-list" role="listbox"></ul>
             </div>
           </div>
         </div>
-        <button class="swap-btn" id="swap-btn" title="Swap models">⇄</button>
+        <button class="swap-btn" id="swap-btn" title="交换模型" data-i18n-title="swap.title">⇄</button>
         <div class="selector-group">
-          <label>Model B</label>
+          <label data-i18n="cmp.model_b">模型 B</label>
           <div class="custom-select-container" id="compare-b-custom-select">
             <button class="custom-select-trigger" aria-haspopup="listbox" aria-expanded="false">
-              <span class="trigger-content">Select model...</span>
+              <span class="trigger-content">请选择模型…</span>
               <span class="trigger-arrow">▼</span>
             </button>
             <div class="custom-select-dropdown">
               <div class="dropdown-search-wrap">
-                <input type="text" class="dropdown-search-input" placeholder="🔍 Search models...">
+                <input type="text" class="dropdown-search-input" data-i18n-ph="ex.search_ph" placeholder="🔍 搜索模型…">
               </div>
               <ul class="dropdown-list" role="listbox"></ul>
             </div>
@@ -303,16 +304,16 @@
       </div>
       <div class="chart-row chart-row-2" style="margin-bottom:20px">
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Head-to-Head Stats</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.h2h">一对一统计</span></div>
           <table class="h2h-table" id="h2h-table"></table>
         </div>
         <div class="card">
-          <div class="card-title"><span class="dot"></span>Response Time Overlay</div>
+          <div class="card-title"><span class="dot"></span><span data-i18n="card.resp_overlay">响应时间叠加</span></div>
           <div class="chart-wrap-lg"><canvas id="chart-compare-time"></canvas></div>
         </div>
       </div>
       <div class="card">
-        <div class="card-title"><span class="dot"></span>Win Timeline (per run)</div>
+        <div class="card-title"><span class="dot"></span><span data-i18n="card.win_timeline">胜负时间线（每次运行）</span></div>
         <div class="chart-wrap"><canvas id="chart-compare-wins"></canvas></div>
       </div>
     </section>
@@ -320,6 +321,7 @@
 </div>
 
 
+<script src="js/i18n.js"></script>
 <script src="js/helpers.js"></script>
 <script src="js/data.js"></script>
 <script src="js/charts.js"></script>

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -95,12 +95,14 @@ function providerChip(m, small) {
 
 function fmtTimestamp(ts) {
   const d = new Date(ts);
-  return d.toLocaleString('en', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false });
+  const loc = window.getUiLocale ? window.getUiLocale() : 'en-US';
+  return d.toLocaleString(loc, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: false });
 }
 
 function fmtTimestampShort(ts) {
   const d = new Date(ts);
-  const mo = d.toLocaleString('en', { month: 'short' });
+  const loc = window.getUiLocale ? window.getUiLocale() : 'en-US';
+  const mo = d.toLocaleString(loc, { month: 'short' });
   const day = d.getDate();
   const hh = String(d.getHours()).padStart(2, '0');
   const mm = String(d.getMinutes()).padStart(2, '0');
@@ -108,13 +110,13 @@ function fmtTimestampShort(ts) {
 }
 
 function categorizeError(err) {
-  if (!err) return 'Unknown';
-  if (err.includes('timed out')) return 'Timeout';
-  if (err.includes('JSON')) return 'JSON Error';
-  if (err.includes('404')) return 'Not Found (404)';
-  if (err.includes('410')) return 'Gone (410)';
-  if (err.includes('closed connection')) return 'Connection Closed';
-  return 'Other Error';
+  if (!err) return 'err.unknown';
+  if (err.includes('timed out')) return 'err.timeout';
+  if (err.includes('JSON')) return 'err.json';
+  if (err.includes('404')) return 'err.404';
+  if (err.includes('410')) return 'err.410';
+  if (err.includes('closed connection')) return 'err.closed';
+  return 'err.other';
 }
 
 function modelColor(model) {

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,0 +1,453 @@
+// ─── i18n: 中英切换 (Chinese / English toggle) ───────────────────────────────
+window.I18N_LANG = localStorage.getItem('lang') || 'en';
+
+window.I18N = {
+  zh: {
+    // 导航 / Navigation
+    'nav.overview': '概览',
+    'nav.leaderboard': '排行榜',
+    'nav.explorer': '模型详情',
+    'nav.timeline': '时间线',
+    'nav.compare': '对比',
+    'theme.toggle': '切换主题',
+
+    // 加载 / Loading
+    'loading.text': '正在加载基准测试数据…',
+
+    // 错误 / Error
+    'error.title': '加载基准测试数据失败',
+    'error.msg': '错误：{msg}。请确保 history.db 存在且通过 HTTP 方式访问本页面。',
+
+    // 概览 / Overview
+    'ov.title': '仪表盘概览',
+    'ov.runs_limit': '运行次数：',
+    'ov.limit.30': '30 次',
+    'ov.limit.50': '50 次',
+    'ov.limit.100': '100 次',
+    'ov.limit.all': '全部',
+    'card.model_intel': '模型智能指数',
+    'card.value_frontier': '智能 vs. 吞吐（价值前沿）',
+    'no_intel': '⚠️ 请提供 ARTIFICIAL_ANALYSIS_API_KEY 以加载基准分数',
+    'no_scatter': '⚠️ 请提供 ARTIFICIAL_ANALYSIS_API_KEY 以加载价值前沿',
+    'card.success_count': '每次运行成功数',
+    'card.success_rate': '成功率趋势',
+    'card.fastest': '最快模型 Top 10（平均）',
+    'card.throughput': '最高吞吐 Top 10（tok/s）',
+    'card.reliability': '模型可靠性',
+
+    // 排行榜 / Leaderboard
+    'lb.title': '模型排行榜',
+    'lb.sub': '按综合评分排名 - 点击某行查看该模型详情',
+    'lb.search_ph': '🔍 按模型名称筛选…',
+    'th.rank': '#',
+    'th.model': '模型',
+    'th.score': '评分',
+    'th.uptime': '在线率',
+    'th.intelligence': '智能',
+    'th.avgTime': '平均耗时',
+    'th.avgTtft': '首字延迟',
+    'th.bestTime': '最佳耗时',
+    'th.avgTps': '吞吐',
+    'th.wins': '胜场',
+    'th.trend': '趋势',
+
+    // 模型详情 / Explorer
+    'ex.select_model': '选择模型',
+    'ex.placeholder': '请选择模型…',
+    'ex.search_ph': '🔍 搜索模型…',
+    'ex.last_seen': '最近出现：{ts}',
+    'card.radar': '模型能力拆解（雷达图）',
+    'no_radar': '⚠️ 请提供 ARTIFICIAL_ANALYSIS_API_KEY 以查看能力雷达图',
+    'card.compare_profile': '模型表现 vs. 全局平均',
+    'no_comparison': '⚠️ 请提供 ARTIFICIAL_ANALYSIS_API_KEY 以查看对比数据',
+    'card.resp_history': '响应时间历史',
+    'card.error_breakdown': '错误分布',
+    'no_errors': '🎉 100% 成功率 - 无错误！',
+    'card.heatmap': '可用性热力图',
+    'card.run_history': '运行历史（最近 20 次）',
+    'th.timestamp': '时间',
+    'th.status': '状态',
+    'th.response_time': '响应时间',
+    'th.tok_s': 'Tok/s',
+    'th.error': '错误',
+
+    // 时间线 / Timeline
+    'tl.title': '运行时间线',
+    'tl.filter.all': '全部',
+    'tl.filter.24h': '最近 24 小时',
+    'tl.filter.48h': '最近 48 小时',
+    'tl.filter.7d': '最近 7 天',
+
+    // 对比 / Compare
+    'cmp.title': '模型对比',
+    'cmp.sub': '一对一对比分析',
+    'cmp.model_a': '模型 A',
+    'cmp.model_b': '模型 B',
+    'swap.title': '交换模型',
+    'card.h2h': '一对一统计',
+    'card.resp_overlay': '响应时间叠加',
+    'card.win_timeline': '胜负时间线（每次运行）',
+
+    // 错误分类 / Error categories
+    'err.unknown': '未知',
+    'err.timeout': '超时',
+    'err.json': 'JSON 错误',
+    'err.404': '未找到 (404)',
+    'err.410': '已移除 (410)',
+    'err.closed': '连接已关闭',
+    'err.other': '其他错误',
+
+    // 状态栏 / Nav status
+    'nav.status': '{runs} 次运行 · {models} 个模型',
+
+    // 下拉列表项 / Dropdown items
+    'dropdown.stats': '在线率：{up} | 速度：{sp}',
+    'dropdown.score': '评分：{score}',
+
+    // KPI
+    'kpi.total_runs': '总运行数',
+    'kpi.avg_success': '平均成功率',
+    'kpi.avg_best_resp': '平均最佳响应',
+    'kpi.avg_best_tps': '平均最佳吞吐',
+    'kpi.most_reliable': '最稳定',
+    'kpi.sub_all': '覆盖全部运行与模型',
+    'ov.sub': '{runs} 次基准运行 · {models} 个模型 · {from} 至 {to}',
+
+    // 图表 / Charts
+    'chart.success_count': '成功数',
+    'chart.success_rate': '成功率',
+    'chart.run_tooltip': '第 {n} 次运行: {label}',
+    'chart.success_pct': '{v}% 成功率',
+    'chart.avg': '平均：{v}s',
+    'chart.tok_s': '{v} tok/s',
+    'chart.intel_val': '智能：{v}',
+    'chart.scatter': '{m}：速度 = {sp} t/s，智能 = {int}',
+    'chart.axis_throughput': '吞吐量（tokens/秒）',
+    'chart.axis_intel': '智能指数',
+    'chart.resp_seconds': '响应时间 (秒)',
+    'chart.failed': '失败',
+
+    // 趋势 / Trend
+    'trend.up': '上升',
+    'trend.down': '下降',
+    'trend.flat': '稳定',
+
+    // 模型详情统计 / Explorer stats
+    'stat.uptime': '在线率',
+    'stat.intel': '智能指数',
+    'stat.avg_resp': '平均响应',
+    'stat.avg_ttft': '平均首字延迟',
+    'stat.ttft_sub': '首字延迟',
+    'stat.best_resp': '最佳响应',
+    'stat.avg_tps': '平均吞吐',
+    'stat.runs_sub': '{s}/{t} 次运行',
+
+    // 雷达图 / Radar
+    'radar.reliability': '可靠性 (%)',
+    'radar.intelligence': '智能指数',
+    'radar.avg_resp': '平均响应 (秒)',
+    'radar.avg_tps': '平均吞吐 (t/s)',
+    'radar.reasoning': '推理指数',
+    'radar.coding': '代码指数',
+    'radar.global': '全局平均',
+    'radar.tooltip': '{label} {axis}: {v}',
+
+    // 对比 tooltip
+    'cmp.rel_tooltip': '{label} 可靠性：{v}% 在线率',
+    'cmp.intel_tooltip': '{label} 智能：{v} 指数',
+    'cmp.resp_tooltip': '{label} 平均响应：{v}s',
+    'cmp.tps_tooltip': '{label} 平均吞吐：{v} t/s',
+
+    // 热力图 / 运行历史 tooltip
+    'hm.no_data': '第 {n} 次运行：无数据',
+    'hm.ok': '{ts}: ✓ {t}s',
+    'hm.fail': '{ts}: ✗ {err}',
+    'run.ok': '✓ 正常',
+    'run.fail': '✗ 失败',
+
+    // 时间线卡片 / Timeline cards
+    'tl.badge': '{n} 次运行',
+    'tl.prompt': '提示词：{p}',
+    'tl.th.model': '模型',
+    'tl.th.status': '状态',
+    'tl.th.resp': '响应时间',
+    'tl.th.tok_s': 'Tok/s',
+    'tl.th.error': '错误',
+
+    // 对比指标表 / Compare metrics
+    'm.uptime': '在线率',
+    'm.intel': '智能指数',
+    'm.avg_resp': '平均响应时间',
+    'm.best_resp': '最佳响应时间',
+    'm.avg_tps': '平均吞吐',
+    'm.wins': '总胜场',
+    'm.score': '评分',
+    'm.h2h': '对战胜率',
+    'h2h.metric': '指标',
+    'cmp.overlay_fail': '{label}：失败',
+    'cmp.win_per_run': '每轮胜者',
+    'cmp.both_failed': '双方均失败',
+    'cmp.won': '{m} 获胜'
+  },
+
+  en: {
+    // 导航 / Navigation
+    'nav.overview': 'Overview',
+    'nav.leaderboard': 'Leaderboard',
+    'nav.explorer': 'Explorer',
+    'nav.timeline': 'Timeline',
+    'nav.compare': 'Compare',
+    'theme.toggle': 'Toggle Theme',
+
+    // 加载 / Loading
+    'loading.text': 'Loading benchmark data…',
+
+    // 错误 / Error
+    'error.title': 'Failed to load benchmark data',
+    'error.msg': 'Error: {msg}. Make sure history.db exists and you\'re serving this page via HTTP.',
+
+    // 概览 / Overview
+    'ov.title': 'Dashboard Overview',
+    'ov.runs_limit': 'Runs limit:',
+    'ov.limit.30': '30 runs',
+    'ov.limit.50': '50 runs',
+    'ov.limit.100': '100 runs',
+    'ov.limit.all': 'All',
+    'card.model_intel': 'Model Intelligence Index',
+    'card.value_frontier': 'Intelligence vs. Throughput (Value Frontier)',
+    'no_intel': '⚠️ Supply ARTIFICIAL_ANALYSIS_API_KEY to load benchmark scores',
+    'no_scatter': '⚠️ Supply ARTIFICIAL_ANALYSIS_API_KEY to load value frontier',
+    'card.success_count': 'Success Count per Run',
+    'card.success_rate': 'Success Rate Over Time',
+    'card.fastest': 'Top 10 Fastest Models (Avg)',
+    'card.throughput': 'Top 10 Throughput (tok/s)',
+    'card.reliability': 'Model Reliability',
+
+    // 排行榜 / Leaderboard
+    'lb.title': 'Model Leaderboard',
+    'lb.sub': 'Ranked by composite score - click a row to explore that model',
+    'lb.search_ph': '🔍 Filter by model name…',
+    'th.rank': '#',
+    'th.model': 'Model',
+    'th.score': 'Score',
+    'th.uptime': 'Uptime',
+    'th.intelligence': 'Intel',
+    'th.avgTime': 'Avg Time',
+    'th.avgTtft': 'TTFT',
+    'th.bestTime': 'Best Time',
+    'th.avgTps': 'Throughput',
+    'th.wins': 'Wins',
+    'th.trend': 'Trend',
+
+    // 模型详情 / Explorer
+    'ex.select_model': 'Select Model',
+    'ex.placeholder': 'Select a model...',
+    'ex.search_ph': '🔍 Search models...',
+    'ex.last_seen': 'Last seen: {ts}',
+    'card.radar': 'Model Capability Breakdown (Radar)',
+    'no_radar': '⚠️ Supply ARTIFICIAL_ANALYSIS_API_KEY to view radar capabilities',
+    'card.compare_profile': 'Model Performance vs. Global Average',
+    'no_comparison': '⚠️ Supply ARTIFICIAL_ANALYSIS_API_KEY to view comparison stats',
+    'card.resp_history': 'Response Time History',
+    'card.error_breakdown': 'Error Breakdown',
+    'no_errors': '🎉 100% Success Rate - No Errors!',
+    'card.heatmap': 'Availability Heatmap',
+    'card.run_history': 'Run History (last 20)',
+    'th.timestamp': 'Timestamp',
+    'th.status': 'Status',
+    'th.response_time': 'Response Time',
+    'th.tok_s': 'Tok/s',
+    'th.error': 'Error',
+
+    // 时间线 / Timeline
+    'tl.title': 'Run Timeline',
+    'tl.filter.all': 'All',
+    'tl.filter.24h': 'Last 24h',
+    'tl.filter.48h': 'Last 48h',
+    'tl.filter.7d': 'Last 7d',
+
+    // 对比 / Compare
+    'cmp.title': 'Model Comparison',
+    'cmp.sub': 'Head-to-head analysis',
+    'cmp.model_a': 'Model A',
+    'cmp.model_b': 'Model B',
+    'swap.title': 'Swap models',
+    'card.h2h': 'Head-to-Head Stats',
+    'card.resp_overlay': 'Response Time Overlay',
+    'card.win_timeline': 'Win Timeline (per run)',
+
+    // 错误分类 / Error categories
+    'err.unknown': 'Unknown',
+    'err.timeout': 'Timeout',
+    'err.json': 'JSON Error',
+    'err.404': 'Not Found (404)',
+    'err.410': 'Gone (410)',
+    'err.closed': 'Connection Closed',
+    'err.other': 'Other Error',
+
+    // 状态栏 / Nav status
+    'nav.status': '{runs} runs · {models} models',
+
+    // 下拉列表项 / Dropdown items
+    'dropdown.stats': 'Uptime: {up} | Speed: {sp}',
+    'dropdown.score': 'Score: {score}',
+
+    // KPI
+    'kpi.total_runs': 'Total Runs',
+    'kpi.avg_success': 'Avg Success Rate',
+    'kpi.avg_best_resp': 'Avg Best Response',
+    'kpi.avg_best_tps': 'Avg Best Throughput',
+    'kpi.most_reliable': 'Most Reliable',
+    'kpi.sub_all': 'across all runs & models',
+    'ov.sub': '{runs} benchmark runs · {models} models · {from} to {to}',
+
+    // 图表 / Charts
+    'chart.success_count': 'Successes',
+    'chart.success_rate': 'Success Rate',
+    'chart.run_tooltip': 'Run {n}: {label}',
+    'chart.success_pct': '{v}% success',
+    'chart.avg': 'Avg: {v}s',
+    'chart.tok_s': '{v} tok/s',
+    'chart.intel_val': 'Intelligence: {v}',
+    'chart.scatter': '{m}: Speed = {sp} t/s, Intel = {int}',
+    'chart.axis_throughput': 'Throughput (tokens/sec)',
+    'chart.axis_intel': 'Intelligence Index',
+    'chart.resp_seconds': 'Response Time (s)',
+    'chart.failed': 'Failed',
+
+    // 趋势 / Trend
+    'trend.up': 'Improving',
+    'trend.down': 'Declining',
+    'trend.flat': 'Stable',
+
+    // 模型详情统计 / Explorer stats
+    'stat.uptime': 'Uptime',
+    'stat.intel': 'Intel Index',
+    'stat.avg_resp': 'Avg Response',
+    'stat.avg_ttft': 'Avg TTFT',
+    'stat.ttft_sub': 'Time to 1st Token',
+    'stat.best_resp': 'Best Response',
+    'stat.avg_tps': 'Avg Throughput',
+    'stat.runs_sub': '{s}/{t} runs',
+
+    // 雷达图 / Radar
+    'radar.reliability': 'Reliability (%)',
+    'radar.intelligence': 'Intelligence Index',
+    'radar.avg_resp': 'Avg Response (s)',
+    'radar.avg_tps': 'Avg Throughput (t/s)',
+    'radar.reasoning': 'Reasoning Index',
+    'radar.coding': 'Coding Index',
+    'radar.global': 'Global Average',
+    'radar.tooltip': '{label} {axis}: {v}',
+
+    // 对比 tooltip
+    'cmp.rel_tooltip': '{label} Reliability: {v}% Uptime',
+    'cmp.intel_tooltip': '{label} Intelligence: {v} Index',
+    'cmp.resp_tooltip': '{label} Avg Response: {v}s',
+    'cmp.tps_tooltip': '{label} Avg Throughput: {v} t/s',
+
+    // 热力图 / 运行历史 tooltip
+    'hm.no_data': 'Run {n}: No data',
+    'hm.ok': '{ts}: ✓ {t}s',
+    'hm.fail': '{ts}: ✗ {err}',
+    'run.ok': '✓ OK',
+    'run.fail': '✗ Fail',
+
+    // 时间线卡片 / Timeline cards
+    'tl.badge': '{n} runs',
+    'tl.prompt': 'Prompt: {p}',
+    'tl.th.model': 'Model',
+    'tl.th.status': 'Status',
+    'tl.th.resp': 'Response Time',
+    'tl.th.tok_s': 'Tok/s',
+    'tl.th.error': 'Error',
+
+    // 对比指标表 / Compare metrics
+    'm.uptime': 'Uptime',
+    'm.intel': 'Intelligence Index',
+    'm.avg_resp': 'Avg Response Time',
+    'm.best_resp': 'Best Response Time',
+    'm.avg_tps': 'Avg Throughput',
+    'm.wins': 'Total Wins',
+    'm.score': 'Score',
+    'm.h2h': 'H2H Win Rate',
+    'h2h.metric': 'Metric',
+    'cmp.overlay_fail': '{label}: Failed',
+    'cmp.win_per_run': 'Winner per run',
+    'cmp.both_failed': 'Both failed',
+    'cmp.won': '{m} won'
+  }
+};
+
+// 语言元信息：新增一门语言 = 这里加一行 + I18N 里加一份字典，切换下拉会自动出现
+window.LANG_META = {
+  zh: { label: '中文', htmlLang: 'zh-CN', locale: 'zh-CN' },
+  en: { label: 'EN',   htmlLang: 'en',    locale: 'en-US' },
+};
+
+// 翻译函数 / translation helper
+window.t = function (key, vars) {
+  const dict = window.I18N[window.I18N_LANG] || window.I18N.zh;
+  let s = (dict[key] != null) ? dict[key] : (window.I18N.zh[key] != null ? window.I18N.zh[key] : key);
+  if (vars && typeof vars === 'object') {
+    for (const k in vars) {
+      s = s.replace(new RegExp('\\{' + k + '\\}', 'g'), vars[k]);
+    }
+  }
+  return s;
+};
+
+// 日期本地化 locale
+window.getUiLocale = function () {
+  const m = window.LANG_META[window.I18N_LANG];
+  return m ? m.locale : 'en-US';
+};
+
+// 根据 I18N 中实际存在的语种自动生成切换下拉项；加新语言无需改这里
+function populateLangSelect() {
+  const sel = document.getElementById('lang-select');
+  if (!sel) return;
+  const cur = window.I18N_LANG;
+  sel.innerHTML = '';
+  Object.keys(window.I18N).forEach(code => {
+    const meta = window.LANG_META[code] || { label: code };
+    const opt = document.createElement('option');
+    opt.value = code;
+    opt.textContent = meta.label;
+    if (code === cur) opt.selected = true;
+    sel.appendChild(opt);
+  });
+}
+
+// 应用语言到所有静态标记元素
+window.applyLang = function () {
+  const lm = window.LANG_META[window.I18N_LANG];
+  document.documentElement.lang = lm ? lm.htmlLang : 'en';
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = window.t(el.getAttribute('data-i18n'));
+  });
+  document.querySelectorAll('[data-i18n-title]').forEach(el => {
+    el.title = window.t(el.getAttribute('data-i18n-title'));
+  });
+  document.querySelectorAll('[data-i18n-ph]').forEach(el => {
+    el.placeholder = window.t(el.getAttribute('data-i18n-ph'));
+  });
+  populateLangSelect();
+};
+
+// 切换并重新渲染动态内容（图表/表格/下拉）
+window.setLang = function (lang) {
+  window.I18N_LANG = lang;
+  try { localStorage.setItem('lang', lang); } catch (e) {}
+  window.applyLang();
+  if (typeof updateNavStatus === 'function') updateNavStatus();
+  if (typeof switchTab === 'function' && typeof state !== 'undefined' && state) {
+    // 关闭所有下拉，使其下次打开时以新语言渲染
+    document.querySelectorAll('.custom-select-container.open').forEach(c => c.classList.remove('open'));
+    switchTab(state.currentTab);
+  }
+};
+
+window.toggleLang = function () {
+  window.setLang(window.I18N_LANG === 'zh' ? 'en' : 'zh');
+};

--- a/js/main.js
+++ b/js/main.js
@@ -12,7 +12,7 @@ function createCustomDropdown(containerId, options, activeValue, onChangeCallbac
   // Helper to set trigger content based on selection
   function updateTrigger(val) {
     if (!val) {
-      triggerContent.innerHTML = 'Select a model...';
+      triggerContent.innerHTML = t('ex.placeholder');
       return;
     }
     const pm = providerMeta(val);
@@ -23,7 +23,7 @@ function createCustomDropdown(containerId, options, activeValue, onChangeCallbac
     triggerContent.innerHTML = `
       ${providerChip(val, true)}
       <span style="font-weight:600;font-size:13px">${short}</span>
-      <span style="font-size:10px;font-weight:700;background:var(--bg-card2);padding:1px 5px;border-radius:4px;color:${scoreColor};font-family:'JetBrains Mono'">Score: ${score}</span>
+      <span style="font-size:10px;font-weight:700;background:var(--bg-card2);padding:1px 5px;border-radius:4px;color:${scoreColor};font-family:'JetBrains Mono'">评分：${score}</span>
     `;
   }
 
@@ -84,10 +84,10 @@ function createCustomDropdown(containerId, options, activeValue, onChangeCallbac
             <div class="dropdown-item-name">${short}</div>
             <div class="dropdown-item-details">
               ${providerChip(opt, true)}
-              <span class="dropdown-item-stats">Up: ${uptimePct} | Speed: ${avgSpeed}</span>
+              <span class="dropdown-item-stats">${t('dropdown.stats', { up: uptimePct, sp: avgSpeed })}</span>
             </div>
           </div>
-          <span class="dropdown-item-score-badge" style="background:${scoreBg};color:${scoreColor}">Score: ${s.score || 0}</span>
+          <span class="dropdown-item-score-badge" style="background:${scoreBg};color:${scoreColor}">${t('dropdown.score', { score: s.score || 0 })}</span>
         </li>
       `;
     }).join('');
@@ -271,8 +271,7 @@ async function init() {
     state.compareModelB = state.modelNames.includes(defaultB) ? defaultB : (sortedModels[1] || sortedModels[0] || '');
 
     // Nav status
-    document.getElementById('nav-status').textContent =
-      `${state.rawRuns.length} runs · ${state.modelNames.length} models`;
+    updateNavStatus();
 
     // Populate selects
     populateExplorerSelect();
@@ -311,12 +310,22 @@ async function init() {
     setTimeout(updateAllIndicators, 100);
     window.addEventListener('resize', updateAllIndicators);
 
+    // 应用当前语言到静态标记（导航、卡片、表格、按钮等）
+    applyLang();
+
   } catch (err) {
     document.getElementById('loading').style.display = 'none';
     document.getElementById('app').classList.add('visible');
     document.getElementById('error-state').style.display = 'flex';
-    document.getElementById('error-msg').textContent = `Error: ${err.message}. Make sure history.db exists and you're serving via HTTP.`;
+    document.getElementById('error-msg').textContent = t('error.msg', { msg: err.message });
     console.error('Failed to load data:', err);
+  }
+}
+
+function updateNavStatus() {
+  const el = document.getElementById('nav-status');
+  if (el && state.rawRuns) {
+    el.textContent = t('nav.status', { runs: state.rawRuns.length, models: state.modelNames.length });
   }
 }
 

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -17,11 +17,11 @@ function renderOverview() {
   const mostReliable = [...modelNames].sort((a, b) => modelStats[b].uptime - modelStats[a].uptime)[0];
 
   const kpiData = [
-    { icon: '🔁', label: 'Total Runs', val: totalRuns, sub: `${runs[0]?.timestamp?.slice(0,10)} → ${runs[runs.length-1]?.timestamp?.slice(0,10)}`, decimals: 0 },
-    { icon: '✅', label: 'Avg Success Rate', val: avgSuccessRate, suffix: '%', decimals: 1, sub: 'across all runs & models' },
-    { icon: '⚡', label: 'Avg Best Response', val: bestTimeVal / 1000, suffix: 's', decimals: 2, sub: bestTimeModel ? shortModel(bestTimeModel) : '' },
-    { icon: '🚀', label: 'Avg Best Throughput', val: bestTpsVal, suffix: ' t/s', decimals: 1, sub: bestTpsModel ? shortModel(bestTpsModel) : '' },
-    { icon: '🏅', label: 'Most Reliable', val: (modelStats[mostReliable]?.uptime || 0) * 100, suffix: '%', decimals: 1, sub: mostReliable ? shortModel(mostReliable) : '' },
+    { icon: '🔁', label: t('kpi.total_runs'), val: totalRuns, sub: `${runs[0]?.timestamp?.slice(0,10)} → ${runs[runs.length-1]?.timestamp?.slice(0,10)}`, decimals: 0 },
+    { icon: '✅', label: t('kpi.avg_success'), val: avgSuccessRate, suffix: '%', decimals: 1, sub: t('kpi.sub_all') },
+    { icon: '⚡', label: t('kpi.avg_best_resp'), val: bestTimeVal / 1000, suffix: 's', decimals: 2, sub: bestTimeModel ? shortModel(bestTimeModel) : '' },
+    { icon: '🚀', label: t('kpi.avg_best_tps'), val: bestTpsVal, suffix: ' t/s', decimals: 1, sub: bestTpsModel ? shortModel(bestTpsModel) : '' },
+    { icon: '🏅', label: t('kpi.most_reliable'), val: (modelStats[mostReliable]?.uptime || 0) * 100, suffix: '%', decimals: 1, sub: mostReliable ? shortModel(mostReliable) : '' },
   ];
 
   const kpiGrid = document.getElementById('kpi-grid');
@@ -39,8 +39,10 @@ function renderOverview() {
     if (el) animateCounter(el, k.val, 1400, k.decimals || 0, k.suffix || '');
   });
 
+  const fromTs = runs[0]?.timestamp?.slice(0,10);
+  const toTs = runs[runs.length-1]?.timestamp?.slice(0,10);
   document.getElementById('overview-sub').textContent =
-    `${totalRuns} benchmark runs · ${modelNames.length} models · ${runs[0]?.timestamp?.slice(0,10)} to ${runs[runs.length-1]?.timestamp?.slice(0,10)}`;
+    t('ov.sub', { runs: totalRuns, models: modelNames.length, from: fromTs, to: toTs });
 
   // Charts
   const labels = runs.map(r => fmtTimestampShort(r.timestamp));
@@ -57,7 +59,7 @@ function renderOverview() {
     data: {
       labels,
       datasets: [{
-        label: 'Successes',
+        label: t('chart.success_count'),
         data: successCounts,
         borderColor: '#76b900',
         backgroundColor: 'rgba(118,185,0,0.08)',
@@ -71,7 +73,7 @@ function renderOverview() {
     options: {
       responsive: true, maintainAspectRatio: false,
       plugins: { legend: { display: false }, tooltip: { ...CHART_DEFAULTS.tooltip, callbacks: {
-        title: (items) => `Run ${items[0].dataIndex + 1}: ${labels[items[0].dataIndex]}`
+        title: (items) => t('chart.run_tooltip', { n: items[0].dataIndex + 1, label: labels[items[0].dataIndex] })
       }}},
       scales: {
         x: { display: false },
@@ -86,7 +88,7 @@ function renderOverview() {
     data: {
       labels,
       datasets: [{
-        label: 'Success %',
+        label: t('chart.success_rate'),
         data: successRates,
         borderColor: '#00c8ff',
         backgroundColor: 'rgba(0,200,255,0.06)',
@@ -100,7 +102,7 @@ function renderOverview() {
     options: {
       responsive: true, maintainAspectRatio: false,
       plugins: { legend: { display: false }, tooltip: { ...CHART_DEFAULTS.tooltip, callbacks: {
-        label: (item) => `${item.raw.toFixed(1)}% success`
+        label: (item) => t('chart.success_pct', { v: item.raw.toFixed(1) })
       }}},
       scales: {
         x: { display: false },
@@ -132,7 +134,7 @@ function renderOverview() {
       indexAxis: 'y',
       responsive: true, maintainAspectRatio: false,
       plugins: { legend: { display: false }, tooltip: { ...CHART_DEFAULTS.tooltip, callbacks: {
-        label: (item) => `Avg: ${item.raw.toFixed(2)}s`
+        label: (item) => t('chart.avg', { v: item.raw.toFixed(2) })
       }}},
       scales: {
         x: { grid: {}, ticks: { callback: v => v + 's' } },
@@ -164,7 +166,7 @@ function renderOverview() {
       indexAxis: 'y',
       responsive: true, maintainAspectRatio: false,
       plugins: { legend: { display: false }, tooltip: { ...CHART_DEFAULTS.tooltip, callbacks: {
-        label: (item) => `${item.raw.toFixed(1)} tok/s`
+        label: (item) => t('chart.tok_s', { v: item.raw.toFixed(1) })
       }}},
       scales: {
         x: { grid: {}, ticks: { callback: v => v + ' t/s' } },
@@ -221,7 +223,7 @@ function renderOverview() {
       options: {
         responsive: true, maintainAspectRatio: false,
         plugins: { legend: { display: false }, tooltip: { ...CHART_DEFAULTS.tooltip, callbacks: {
-          label: (item) => `Intelligence: ${item.raw.toFixed(0)}`
+          label: (item) => t('chart.intel_val', { v: item.raw.toFixed(0) })
         }}},
         scales: {
           x: { grid: { display: false }, ticks: { font: { size: 9 }, autoSkip: false, maxRotation: 45, minRotation: 45 } },
@@ -261,18 +263,18 @@ function renderOverview() {
             callbacks: {
               label: (item) => {
                 const d = item.raw;
-                return `${shortModel(d.model)}: Speed = ${d.x.toFixed(1)} t/s, Intel = ${d.y.toFixed(0)}`;
+                return t('chart.scatter', { m: shortModel(d.model), sp: d.x.toFixed(1), int: d.y.toFixed(0) });
               }
             }
           }
         },
         scales: {
           x: {
-            title: { display: true, text: 'Throughput (tokens/sec)', color: '#9aa0a6', font: { size: 11 } },
+            title: { display: true, text: t('chart.axis_throughput'), color: '#9aa0a6', font: { size: 11 } },
             grid: {}
           },
           y: {
-            title: { display: true, text: 'Intelligence Index', color: '#9aa0a6', font: { size: 11 } },
+            title: { display: true, text: t('chart.axis_intel'), color: '#9aa0a6', font: { size: 11 } },
             grid: {}
           }
         }
@@ -331,10 +333,10 @@ function renderLbTable() {
     const colorVar = r.uptime >= 0.7 ? 'var(--success)' : r.uptime >= 0.4 ? 'var(--warning)' : 'var(--danger)';
     const scoreVar = r.score >= 60 ? 'var(--success)' : r.score >= 40 ? 'var(--warning)' : 'var(--danger)';
     const trendHtml = r.trend === 'up'
-      ? `<span class="trend-indicator trend-up" title="Improving">↑</span>`
+      ? `<span class="trend-indicator trend-up" title="${t('trend.up')}">↑</span>`
       : r.trend === 'down'
-      ? `<span class="trend-indicator trend-down" title="Declining">↓</span>`
-      : `<span class="trend-indicator trend-flat" title="Stable">→</span>`;
+      ? `<span class="trend-indicator trend-down" title="${t('trend.down')}">↓</span>`
+      : `<span class="trend-indicator trend-flat" title="${t('trend.flat')}">→</span>`;
     const last10 = r.responseTimes.slice(-10);
     const spark = sparklineSVG(last10, 72, 22, modelColor(r.model));
     const isTop3 = r.rank <= 3;
@@ -402,19 +404,19 @@ function renderExplorer() {
     ${providerChip(model)}
     <h2>${shortModel(model)}</h2>
     <span style="font-size:12px;color:var(--text-dim);margin-left:auto">
-      Last seen: ${s.lastSeen ? fmtTimestamp(s.lastSeen) : '—'}
+      ${t('ex.last_seen', { ts: s.lastSeen ? fmtTimestamp(s.lastSeen) : '—' })}
     </span>
   `;
 
   // Stats
   const uptimeColor = s.uptime >= 0.7 ? 'var(--success)' : s.uptime >= 0.4 ? 'var(--warning)' : 'var(--danger)';
   document.getElementById('explorer-stats').innerHTML = `
-    <div class="stat-card"><div class="stat-val" style="color:${uptimeColor}">${(s.uptime*100).toFixed(1)}%</div><div class="stat-label">Uptime</div><div class="stat-sub">${s.successCount}/${s.totalRuns} runs</div></div>
-    <div class="stat-card"><div class="stat-val" style="color:var(--purple)">${s.intelligence ? s.intelligence.toFixed(0) : '—'}</div><div class="stat-label">Intel Index</div><div class="stat-sub">Artificial Analysis</div></div>
-    <div class="stat-card"><div class="stat-val">${s.avgTime ? (s.avgTime/1000).toFixed(2)+'s' : '—'}</div><div class="stat-label">Avg Response</div></div>
-    <div class="stat-card"><div class="stat-val" style="color:var(--warning)">${s.avgTtft ? s.avgTtft.toFixed(0)+'ms' : '—'}</div><div class="stat-label">Avg TTFT</div><div class="stat-sub">Time to 1st Token</div></div>
-    <div class="stat-card"><div class="stat-val text-accent">${s.bestTime ? (s.bestTime/1000).toFixed(2)+'s' : '—'}</div><div class="stat-label">Best Response</div></div>
-    <div class="stat-card"><div class="stat-val" style="color:var(--blue)">${s.avgTps ? s.avgTps.toFixed(1)+' t/s' : '—'}</div><div class="stat-label">Avg Throughput</div></div>
+    <div class="stat-card"><div class="stat-val" style="color:${uptimeColor}">${(s.uptime*100).toFixed(1)}%</div><div class="stat-label">${t('stat.uptime')}</div><div class="stat-sub">${t('stat.runs_sub', { s: s.successCount, t: s.totalRuns })}</div></div>
+    <div class="stat-card"><div class="stat-val" style="color:var(--purple)">${s.intelligence ? s.intelligence.toFixed(0) : '—'}</div><div class="stat-label">${t('stat.intel')}</div><div class="stat-sub">Artificial Analysis</div></div>
+    <div class="stat-card"><div class="stat-val">${s.avgTime ? (s.avgTime/1000).toFixed(2)+'s' : '—'}</div><div class="stat-label">${t('stat.avg_resp')}</div></div>
+    <div class="stat-card"><div class="stat-val" style="color:var(--warning)">${s.avgTtft ? s.avgTtft.toFixed(0)+'ms' : '—'}</div><div class="stat-label">${t('stat.avg_ttft')}</div><div class="stat-sub">${t('stat.ttft_sub')}</div></div>
+    <div class="stat-card"><div class="stat-val text-accent">${s.bestTime ? (s.bestTime/1000).toFixed(2)+'s' : '—'}</div><div class="stat-label">${t('stat.best_resp')}</div></div>
+    <div class="stat-card"><div class="stat-val" style="color:var(--blue)">${s.avgTps ? s.avgTps.toFixed(1)+' t/s' : '—'}</div><div class="stat-label">${t('stat.avg_tps')}</div></div>
   `;
 
   // Calculate Global Averages
@@ -445,7 +447,7 @@ function renderExplorer() {
     if (compCanvas) compCanvas.style.display = 'block';
 
     // 1. Radar Chart: Model Capability Breakdown
-    const radarLabels = ['Reliability (%)', 'Intelligence Index', 'Avg Response (s)', 'Avg Throughput (t/s)', 'Reasoning Index', 'Coding Index'];
+    const radarLabels = [t('radar.reliability'), t('radar.intelligence'), t('radar.avg_resp'), t('radar.avg_tps'), t('radar.reasoning'), t('radar.coding')];
     const modelRadarData = [
       s.uptime * 100,
       s.intelligence,
@@ -478,7 +480,7 @@ function renderExplorer() {
             borderWidth: 2
           },
           {
-            label: 'Global Average',
+            label: t('radar.global'),
             data: avgRadarData,
             backgroundColor: 'rgba(154, 160, 166, 0.15)',
             borderColor: '#9aa0a6',
@@ -498,7 +500,7 @@ function renderExplorer() {
               label: (item) => {
                 const label = item.chart.data.labels[item.dataIndex];
                 const val = item.raw;
-                return `${item.dataset.label} ${label}: ${val.toFixed(1)}`;
+                return t('radar.tooltip', { label: item.dataset.label, axis: label, v: val.toFixed(1) });
               }
             }
           }
@@ -520,7 +522,7 @@ function renderExplorer() {
     state.charts.explorerComparison = new Chart(compCanvas, {
       type: 'bar',
       data: {
-        labels: ['Reliability (%)', 'Intelligence Index', 'Avg Response (s)', 'Avg Throughput (t/s)'],
+        labels: [t('radar.reliability'), t('radar.intelligence'), t('radar.avg_resp'), t('radar.avg_tps')],
         datasets: [
           {
             label: shortModel(model),
@@ -536,7 +538,7 @@ function renderExplorer() {
             borderRadius: 4
           },
           {
-            label: 'Global Average',
+            label: t('radar.global'),
             data: [
               avgUptime,
               avgIntel,
@@ -560,15 +562,15 @@ function renderExplorer() {
               label: (item) => {
                 const dataset = item.dataset;
                 const val = item.raw;
-                
+
                 if (item.dataIndex === 0) {
-                  return `${dataset.label} Reliability: ${val.toFixed(1)}% Uptime`;
+                  return t('cmp.rel_tooltip', { label: dataset.label, v: val.toFixed(1) });
                 } else if (item.dataIndex === 1) {
-                  return `${dataset.label} Intelligence: ${val ? val.toFixed(0) : '—'} Index`;
+                  return t('cmp.intel_tooltip', { label: dataset.label, v: val ? val.toFixed(0) : '—' });
                 } else if (item.dataIndex === 2) {
-                  return `${dataset.label} Avg Response: ${val.toFixed(2)}s`;
+                  return t('cmp.resp_tooltip', { label: dataset.label, v: val.toFixed(2) });
                 } else if (item.dataIndex === 3) {
-                  return `${dataset.label} Avg Throughput: ${val.toFixed(1)} t/s`;
+                  return t('cmp.tps_tooltip', { label: dataset.label, v: val.toFixed(1) });
                 }
                 return `${dataset.label}: ${val}`;
               }
@@ -599,7 +601,7 @@ function renderExplorer() {
     data: {
       labels,
       datasets: [{
-        label: 'Response Time (s)',
+        label: t('chart.resp_seconds'),
         data: timeData,
         borderColor: modelColor(model),
         backgroundColor: modelColor(model) + '14',
@@ -614,7 +616,7 @@ function renderExplorer() {
     options: {
       responsive: true, maintainAspectRatio: false,
       plugins: { legend: { display: false }, tooltip: { ...CHART_DEFAULTS.tooltip, callbacks: {
-        label: (item) => item.raw != null ? `${item.raw.toFixed(2)}s` : 'Failed'
+        label: (item) => item.raw != null ? `${item.raw.toFixed(2)}s` : t('chart.failed')
       }}},
       scales: {
         x: { display: false },
@@ -638,7 +640,7 @@ function renderExplorer() {
     state.charts.explorerErrors = new Chart(errorCanvas, {
       type: 'doughnut',
       data: {
-        labels: errorKeys,
+        labels: errorKeys.map(k => t(k)),
         datasets: [{
           data: errorKeys.map(k => s.errors[k]),
           backgroundColor: errorColors.slice(0, errorKeys.length).map(c => c + 'cc'),
@@ -665,10 +667,10 @@ function renderExplorer() {
   hm.innerHTML = reversed.map((r, i) => {
     const runIdx = activeResults.length - 1 - i;
     const globalRunIdx = firstActiveIdx >= 0 ? firstActiveIdx + runIdx : runIdx;
-    if (!r) return `<div class="heatmap-cell miss" title="Run ${globalRunIdx+1}: No data"></div>`;
+    if (!r) return `<div class="heatmap-cell miss" title="${t('hm.no_data', { n: globalRunIdx + 1 })}"></div>`;
     const ts = fmtTimestamp(activeRuns[runIdx]?.timestamp || '');
-    if (r.success) return `<div class="heatmap-cell pass" title="${ts}: ✓ ${(r.responseTime/1000).toFixed(2)}s"></div>`;
-    return `<div class="heatmap-cell fail" title="${ts}: ✗ ${r.error||'Error'}"></div>`;
+    if (r.success) return `<div class="heatmap-cell pass" title="${t('hm.ok', { ts, t: (r.responseTime/1000).toFixed(2) })}"></div>`;
+    return `<div class="heatmap-cell fail" title="${t('hm.fail', { ts, err: r.error || t('err.unknown') })}"></div>`;
   }).join('');
 
   // Run history table
@@ -679,7 +681,7 @@ function renderExplorer() {
     const tps = (r.success && r.responseTime > 0) ? (r.tokensGenerated / (r.responseTime / 1000)).toFixed(1) : null;
     return `<tr>
       <td class="mono" style="font-size:11px">${fmtTimestamp(activeRuns[i]?.timestamp||'')}</td>
-      <td><span class="status-badge ${r.success?'ok':'fail'}">${r.success?'✓ OK':'✗ Fail'}</span></td>
+      <td><span class="status-badge ${r.success?'ok':'fail'}">${r.success ? t('run.ok') : t('run.fail')}</span></td>
       <td class="mono">${r.success ? (r.responseTime/1000).toFixed(2)+'s' : '—'}</td>
       <td class="mono">${tps ? tps+' t/s' : '—'}</td>
     </tr>`;
@@ -704,7 +706,7 @@ function renderTimeline() {
     filtered = filtered.filter(r => new Date(r.timestamp) >= cutoff);
   }
 
-  document.getElementById('timeline-badge').textContent = `${filtered.length} runs`;
+  document.getElementById('timeline-badge').textContent = t('tl.badge', { n: filtered.length });
 
   const container = document.getElementById('run-cards');
   container.innerHTML = filtered.map((run, idx) => {
@@ -723,9 +725,9 @@ function renderTimeline() {
         <span class="run-expand-arrow">▼</span>
       </div>
       <div class="run-card-body">
-        <div class="run-prompt">Prompt: ${escHtml((run.prompt||'').slice(0,120))}${(run.prompt||'').length > 120 ? '…' : ''}</div>
+        <div class="run-prompt">${t('tl.prompt', { p: escHtml((run.prompt||'').slice(0,120)) + ((run.prompt||'').length > 120 ? '…' : '') })}</div>
         <table class="run-detail-table">
-          <thead><tr><th>Model</th><th>Status</th><th>Response Time</th><th>Tok/s</th><th>Error</th></tr></thead>
+          <thead><tr><th>${t('tl.th.model')}</th><th>${t('tl.th.status')}</th><th>${t('tl.th.resp')}</th><th>${t('tl.th.tok_s')}</th><th>${t('tl.th.error')}</th></tr></thead>
           <tbody>${run.models.map(m => {
             const tps = (m.success && m.responseTime > 0) ? (m.tokensGenerated / (m.responseTime / 1000)).toFixed(1) : null;
             const cls = m.success ? 'text-green' : 'text-red';
@@ -770,14 +772,14 @@ function renderCompare() {
   });
 
   const metrics = [
-    { label: 'Uptime', a: (sA.uptime*100).toFixed(1)+'%', b: (sB.uptime*100).toFixed(1)+'%', higherBetter: true, av: sA.uptime, bv: sB.uptime },
-    { label: 'Intelligence Index', a: sA.intelligence ? sA.intelligence.toFixed(0) : '—', b: sB.intelligence ? sB.intelligence.toFixed(0) : '—', higherBetter: true, av: sA.intelligence, bv: sB.intelligence },
-    { label: 'Avg Response Time', a: sA.avgTime ? (sA.avgTime/1000).toFixed(2)+'s' : '—', b: sB.avgTime ? (sB.avgTime/1000).toFixed(2)+'s' : '—', higherBetter: false, av: sA.avgTime, bv: sB.avgTime },
-    { label: 'Best Response Time', a: sA.bestTime ? (sA.bestTime/1000).toFixed(2)+'s' : '—', b: sB.bestTime ? (sB.bestTime/1000).toFixed(2)+'s' : '—', higherBetter: false, av: sA.bestTime, bv: sB.bestTime },
-    { label: 'Avg Throughput', a: sA.avgTps ? sA.avgTps.toFixed(1)+' t/s' : '—', b: sB.avgTps ? sB.avgTps.toFixed(1)+' t/s' : '—', higherBetter: true, av: sA.avgTps, bv: sB.avgTps },
-    { label: 'Total Wins', a: sA.wins, b: sB.wins, higherBetter: true, av: sA.wins, bv: sB.wins },
-    { label: 'Score', a: sA.score, b: sB.score, higherBetter: true, av: sA.score, bv: sB.score },
-    { label: 'H2H Win Rate', a: bothSucceeded ? (winsA/bothSucceeded*100).toFixed(1)+'%' : '—', b: bothSucceeded ? (winsB/bothSucceeded*100).toFixed(1)+'%' : '—', higherBetter: true, av: winsA, bv: winsB },
+    { label: t('m.uptime'), a: (sA.uptime*100).toFixed(1)+'%', b: (sB.uptime*100).toFixed(1)+'%', higherBetter: true, av: sA.uptime, bv: sB.uptime },
+    { label: t('m.intel'), a: sA.intelligence ? sA.intelligence.toFixed(0) : '—', b: sB.intelligence ? sB.intelligence.toFixed(0) : '—', higherBetter: true, av: sA.intelligence, bv: sB.intelligence },
+    { label: t('m.avg_resp'), a: sA.avgTime ? (sA.avgTime/1000).toFixed(2)+'s' : '—', b: sB.avgTime ? (sB.avgTime/1000).toFixed(2)+'s' : '—', higherBetter: false, av: sA.avgTime, bv: sB.avgTime },
+    { label: t('m.best_resp'), a: sA.bestTime ? (sA.bestTime/1000).toFixed(2)+'s' : '—', b: sB.bestTime ? (sB.bestTime/1000).toFixed(2)+'s' : '—', higherBetter: false, av: sA.bestTime, bv: sB.bestTime },
+    { label: t('m.avg_tps'), a: sA.avgTps ? sA.avgTps.toFixed(1)+' t/s' : '—', b: sB.avgTps ? sB.avgTps.toFixed(1)+' t/s' : '—', higherBetter: true, av: sA.avgTps, bv: sB.avgTps },
+    { label: t('m.wins'), a: sA.wins, b: sB.wins, higherBetter: true, av: sA.wins, bv: sB.wins },
+    { label: t('m.score'), a: sA.score, b: sB.score, higherBetter: true, av: sA.score, bv: sB.score },
+    { label: t('m.h2h'), a: bothSucceeded ? (winsA/bothSucceeded*100).toFixed(1)+'%' : '—', b: bothSucceeded ? (winsB/bothSucceeded*100).toFixed(1)+'%' : '—', higherBetter: true, av: winsA, bv: winsB },
   ];
 
   const colorA = modelColor(modelA);
@@ -786,7 +788,7 @@ function renderCompare() {
   document.getElementById('h2h-table').innerHTML = `
     <thead><tr>
       <td class="h2h-val-a" style="color:${colorA};font-size:13px;padding:10px 16px;text-align:center">${providerChip(modelA, true)} ${shortModel(modelA)}</td>
-      <td class="h2h-metric">Metric</td>
+      <td class="h2h-metric">${t('h2h.metric')}</td>
       <td class="h2h-val-b" style="color:${colorB};font-size:13px;padding:10px 16px;text-align:center">${providerChip(modelB, true)} ${shortModel(modelB)}</td>
     </tr></thead>
     <tbody>${metrics.map(m => {
@@ -844,7 +846,7 @@ function renderCompare() {
       plugins: {
         legend: { labels: { boxWidth: 12, font: { size: 11 } } },
         tooltip: { ...CHART_DEFAULTS.tooltip, callbacks: {
-          label: (item) => item.raw != null ? `${item.dataset.label}: ${item.raw.toFixed(2)}s` : `${item.dataset.label}: Failed`
+          label: (item) => item.raw != null ? `${item.dataset.label}: ${item.raw.toFixed(2)}s` : t('cmp.overlay_fail', { label: item.dataset.label })
         }}
       },
       scales: {
@@ -872,7 +874,7 @@ function renderCompare() {
     data: {
       labels,
       datasets: [{
-        label: 'Winner per run',
+        label: t('cmp.win_per_run'),
         data: winData,
         backgroundColor: winData.map(v => v == null ? neutralColor : v > 0 ? colorA + 'cc' : colorB + 'cc'),
         borderColor: winData.map(v => v == null ? neutralColor : v > 0 ? colorA : colorB),
@@ -886,8 +888,8 @@ function renderCompare() {
         legend: { display: false },
         tooltip: { ...CHART_DEFAULTS.tooltip, callbacks: {
           label: (item) => {
-            if (item.raw == null) return 'Both failed';
-            return item.raw > 0 ? `${shortModel(modelA)} won` : `${shortModel(modelB)} won`;
+            if (item.raw == null) return t('cmp.both_failed');
+            return item.raw > 0 ? t('cmp.won', { m: shortModel(modelA) }) : t('cmp.won', { m: shortModel(modelB) });
           }
         }}
       },


### PR DESCRIPTION
Adds a full i18n layer to NIMStats so the dashboard is no longer English-only, based on the contribution in #40 with the following adjustments:

- **English by default** (was Chinese). Also restores English `<meta>`/OG/Twitter/title tags.
- **Dropped unrelated/CI-generated files**: `history.db`, `top/*.json`, `top/*.txt`, and the `benchmark.yml` rewrite (kept manual dispatch and existing action versions — no version downgrades).
- **Minor bug fixes**:
  - `fmtTimestamp`/`fmtTimestampShort` now fall back to `en-US` instead of `zh-CN`.
  - `categorizeError` returns stable i18n keys (`err.timeout`, …) instead of translated strings, so error grouping/counts are language-independent; the error-breakdown chart translates labels at render time.
- `js/i18n.js`: zh/en dictionaries (146 symmetric keys), `t()` helper, `applyLang`/`setLang`, `LANG_META` map, `localStorage` persistence, and an auto-generated language dropdown.
- Static + dynamic UI strings (nav, cards, tables, KPIs, charts, dropdowns, tooltips, error categories) now route through `t()`. Adding a language = one dictionary + one `LANG_META` entry.

Supersedes #40.