### PR TITLE
fix(i18n): loading screen shows default (English) language

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 
 <div id="loading">
   <div class="spinner"></div>
-  <p data-i18n="loading.text">正在加载基准测试数据…</p>
+  <p data-i18n="loading.text">Loading benchmark data…</p>
 </div>
 
 <div id="app">

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1501,3 +1501,13 @@ window.setLang = function (lang) {
 window.toggleLang = function () {
   window.setLang(window.I18N_LANG === 'zh' ? 'en' : 'zh');
 };
+
+// Apply the selected language to static markup as early as possible, so the
+// loading screen and nav render in the correct language before data loads.
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', window.applyLang);
+  } else {
+    window.applyLang();
+  }
+}


### PR DESCRIPTION
## Problem
The text under the loading spinner (before the dashboard loads) rendered in Chinese even though English is the default language.

## Cause
- `index.html` had the loading `<p data-i18n="loading.text">` hardcoded to Chinese.
- `applyLang()` was only called at the end of `init()` (after the data fetch), so the first paint showed the static Chinese text.

## Fix
- Set the loading markup default to English.
- Call `applyLang()` on `DOMContentLoaded` (or immediately if the DOM is already ready) so static `data-i18n` elements — including the loading screen and nav — are translated before the dashboard data loads.